### PR TITLE
Add auto deployment

### DIFF
--- a/Build/deploy.PSDeploy.ps1
+++ b/Build/deploy.PSDeploy.ps1
@@ -18,11 +18,13 @@
 # * Set-BuildEnvironment from BuildHelpers module has populated ENV:BHModulePath and related variables
 
 # Publish to gallery with a few restrictions
+$CommitID = git rev-list -n 1 $env:BHBranchName
+$BranchesContainMaster = (git branch --contains $CommitID).Trim() -match '^\*?master$'
 if (
     $env:BHModulePath -and
     $env:BHBuildSystem -ne 'Unknown' -and
-    $env:BHBranchName -eq "master" -and
-    (git describe --tags) -match '^\d\.\d\.\d$'
+    [version]::TryParse($env:BHBranchName, [ref]$null) -and
+    $BranchesContainMaster
 ) {
     Deploy Module {
         By PSGalleryModule {
@@ -37,7 +39,7 @@ if (
 else {
     "Skipping deployment: To deploy, ensure that...`n" +
     "`t* You are in a known build system (Current: $ENV:BHBuildSystem)`n" +
-    "`t* You are committing to the master branch (Current: $ENV:BHBranchName)" +
-    "`t* You are deploying from a tagged release" |
+    "`t* You are deploying from a tagged release (Current tag/branch: $ENV:BHBranchName)`n" +
+    "`t* You have tagged the master branch (Tagged branch contains the master branch: $BranchesContainMaster)" |
         Write-Host
 }

--- a/Build/psake.ps1
+++ b/Build/psake.ps1
@@ -189,6 +189,19 @@ Task TestAfterBuild -Depends BuildDocs {
 Task Deploy -Depends TestAfterBuild {
     $lines
 
+    "`n`tTesting for PowerShell Gallery API key"
+    if (-not $ENV:PSREPO_APIKEY) {
+        Write-Error "PowerShell Gallery API key not found"
+    }
+
+    $Params = @{
+        Path    = "$ENV:BHProjectPath\Build"
+        Force   = $true
+        Recurse = $false # We keep psdeploy artifacts, avoid deploying those : )
+    }
+    "`tInvoking PSDeploy"
+    Invoke-PSDeploy @Verbose @Params
+
     "`tSetting git repository url"
     if (!$ENV:GITHUB_PAT) {
         Write-Error "GitHub personal access token not found"
@@ -202,17 +215,4 @@ Task Deploy -Depends TestAfterBuild {
     git commit -m "Bump version to $ReleaseVersion`n***NO_CI***"
     # --porcelain is to stop git sending output to stderr
     git push $GitHubUrl HEAD:master --porcelain
-
-    "`n`tTesting for PowerShell Gallery API key"
-    if (-not $ENV:PSREPO_APIKEY) {
-        Write-Error "PowerShell Gallery API key not found"
-    }
-
-    $Params = @{
-        Path    = "$ENV:BHProjectPath\Build"
-        Force   = $true
-        Recurse = $false # We keep psdeploy artifacts, avoid deploying those : )
-    }
-    "`tInvoking PSDeploy"
-    Invoke-PSDeploy @Verbose @Params
 }


### PR DESCRIPTION

Parse commit branches and tags to ensure we only deploy off a master tag