### PR TITLE
Test SYSTEM_ACCESSTOKEN env variable instead of GitHub PAT

### DIFF
--- a/Build/psake.ps1
+++ b/Build/psake.ps1
@@ -12,8 +12,8 @@ Properties {
         $Verbose = @{Verbose = $True}
     }
 
-    git config user.email 'sk82jack@hotmail.com'
-    git config user.name 'sk82jack'
+    #git config user.email 'sk82jack@hotmail.com'
+    #git config user.name 'sk82jack'
 }
 
 Task Default -Depends Test
@@ -30,10 +30,10 @@ Task SetBuildVersion -Depends Init {
     $lines
 
     "`n`tSetting git repository url"
-    if (!$ENV:GITHUB_PAT) {
+    if (!$Env:System_AccessToken) {
         Write-Error "GitHub personal access token not found"
     }
-    $GitHubUrl = 'https://{0}@github.com/sk82jack/PSFPL.git' -f $ENV:GITHUB_PAT
+    $GitHubUrl = 'https://{0}@github.com/sk82jack/PSFPL.git' -f $Env:System_AccessToken
 
     "`tSetting build version"
     $BuildVersionPath = "$ENV:BHProjectPath\BUILDVERSION.md"
@@ -214,10 +214,10 @@ Task Deploy -Depends TestAfterBuild {
     Invoke-PSDeploy @Verbose @Params
 
     "`tSetting git repository url"
-    if (!$ENV:GITHUB_PAT) {
+    if (!$Env:System_AccessToken) {
         Write-Error "GitHub personal access token not found"
     }
-    $GitHubUrl = 'https://{0}@github.com/sk82jack/PSFPL.git' -f $ENV:GITHUB_PAT
+    $GitHubUrl = 'https://{0}@github.com/sk82jack/PSFPL.git' -f $Env:System_AccessToken
 
     "`tDeploying built docs to GitHub"
     git add "$env:BHProjectPath\docs\*"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       condition: and(always(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       env:
         BUILD_NAME: $(Build.BuildNumber)
-        GITHUB_PAT: $(github.pat)
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       inputs:
         targetType: 'filePath'
         filePath: .\Build\Start-Build.ps1
@@ -50,7 +50,7 @@ jobs:
       displayName: 'Build and deploy'
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
       env:
-        GITHUB_PAT: $(github.pat)
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         PSREPO_APIKEY: $(psrepo.apikey)
       inputs:
         targetType: 'filePath'


### PR DESCRIPTION
Change `$ENV:GitHub_PAT` to `$ENV:System_AccessToken` to remove the need for a GitHub personal access token.

This is a test so may need to be reverted if unsuccessful.