### PR TITLE
Add check to see if any changes have been added to the changelog

### DIFF
--- a/Build/psake.ps1
+++ b/Build/psake.ps1
@@ -165,6 +165,11 @@ Task BuildDocs -depends Build {
 
     [version]$ReleaseVersion = git describe --tags
 
+    $ChangeLogData = Get-ChangeLogData
+    if (-not ($ChangeLogData.Unreleased.Data.psobject.properties.value -ne '')) {
+        Write-Error 'Cannot perform a deploy without updating the changelog'
+    }
+
     $Params = @{
         Path = "$env:BHProjectPath\CHANGELOG.md"
         ReleaseVersion = $ReleaseVersion.ToString()


### PR DESCRIPTION
The last release was released without any changes added to the changelog because I forgot to add them in. So this will check that the changelog has been populated in some way before continuing with the release