### PR TITLE
Change WebName to Name

### DIFF
--- a/PSFPL/PSFPL.Format.ps1xml
+++ b/PSFPL/PSFPL.Format.ps1xml
@@ -25,7 +25,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>WebName</PropertyName>
+                                <PropertyName>Name</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Club</PropertyName>
@@ -289,7 +289,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>WebName</PropertyName>
+                                <PropertyName>Name</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Position</PropertyName>
@@ -338,7 +338,7 @@
                     <TableRowEntry>
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>WebName</PropertyName>
+                                <PropertyName>Name</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
                                 <PropertyName>Position</PropertyName>

--- a/PSFPL/Private/ConvertTo-FplObject.ps1
+++ b/PSFPL/Private/ConvertTo-FplObject.ps1
@@ -70,124 +70,125 @@ function ConvertTo-FplObject {
             $Hashtable[$Name] = $Value
         }
 
-    switch ($Type) {
-        'FplPlayer' {
-            $Hashtable['PlayerId'] = $Hashtable['Id']
-            $Hashtable.Remove('Id')
-            $Hashtable['Name'] = $Hashtable['WebName']
-            $Hashtable['Position'] = $PositionHash[$Object.element_type]
-            $Hashtable['ClubId'] = $Hashtable['Club']
-            $Hashtable['Club'] = $TeamHash[$Hashtable['Club']]
-            $Hashtable['Price'] = $Object.now_cost / 10
-        }
-        'FplGameweek' {
-            $Hashtable['Gameweek'] = $Hashtable['Id']
-            $Hashtable.Remove('Id')
-            $Hashtable['DeadlineTime'] = Get-Date $Object.deadline_time
-        }
-        'FplFixture' {
-            $Hashtable['FixtureId'] = $Hashtable['Id']
-            $Hashtable.Remove('Id')
-            $Hashtable['DeadlineTime'] = try {
-                Get-Date $Object.deadline_time
+        switch ($Type) {
+            'FplPlayer' {
+                $Hashtable['PlayerId'] = $Hashtable['Id']
+                $Hashtable.Remove('Id')
+                $Hashtable['Name'] = $Hashtable['WebName']
+                $Hashtable['Position'] = $PositionHash[$Object.element_type]
+                $Hashtable['ClubId'] = $Hashtable['Club']
+                $Hashtable['Club'] = $TeamHash[$Hashtable['Club']]
+                $Hashtable['Price'] = $Object.now_cost / 10
             }
-            catch {
-                'tbc'
+            'FplGameweek' {
+                $Hashtable['GameweekId'] = $Hashtable['Id']
+                $Hashtable['Gameweek'] = $Hashtable['Id']
+                $Hashtable.Remove('Id')
+                $Hashtable['DeadlineTime'] = Get-Date $Object.deadline_time
             }
-            $HashTable['KickoffTime'] = try {
-                Get-Date $Object.kickoff_time
-            }
-            catch {
-                'tbc'
-            }
-            if (-not $Hashtable['Gameweek']) {
-                $Hashtable['Gameweek'] = 'tbc'
-            }
-            $Hashtable['ClubA'] = $TeamHash[$Object.team_a]
-            $Hashtable['ClubH'] = $TeamHash[$Object.team_h]
-            $Hashtable['Stats'] = foreach ($Stat in $Hashtable['Stats']) {
-                $StatType = $TextInfo.ToTitleCase($Stat.PSObject.Properties.Name)
-                foreach ($Letter in 'a', 'h') {
-                    $Club = 'Club{0}' -f $Letter.ToUpper()
-                    foreach ($Item in $Stat.$StatType.$Letter) {
-                        [pscustomobject]@{
-                            'PlayerId'   = $Item.element
-                            'PlayerName' = $PlayerHash[$Item.element]
-                            'StatType'   = $StatType -replace '_'
-                            'StatValue'  = $Item.value
-                            'ClubName'   = $Hashtable[$club]
+            'FplFixture' {
+                $Hashtable['FixtureId'] = $Hashtable['Id']
+                $Hashtable.Remove('Id')
+                $Hashtable['DeadlineTime'] = try {
+                    Get-Date $Object.deadline_time
+                }
+                catch {
+                    'tbc'
+                }
+                $HashTable['KickoffTime'] = try {
+                    Get-Date $Object.kickoff_time
+                }
+                catch {
+                    'tbc'
+                }
+                if (-not $Hashtable['Gameweek']) {
+                    $Hashtable['Gameweek'] = 'tbc'
+                }
+                $Hashtable['ClubA'] = $TeamHash[$Object.team_a]
+                $Hashtable['ClubH'] = $TeamHash[$Object.team_h]
+                $Hashtable['Stats'] = foreach ($Stat in $Hashtable['Stats']) {
+                    $StatType = $TextInfo.ToTitleCase($Stat.PSObject.Properties.Name)
+                    foreach ($Letter in 'a', 'h') {
+                        $Club = 'Club{0}' -f $Letter.ToUpper()
+                        foreach ($Item in $Stat.$StatType.$Letter) {
+                            [pscustomobject]@{
+                                'PlayerId'   = $Item.element
+                                'PlayerName' = $PlayerHash[$Item.element]
+                                'StatType'   = $StatType -replace '_'
+                                'StatValue'  = $Item.value
+                                'ClubName'   = $Hashtable[$club]
+                            }
                         }
                     }
                 }
             }
-        }
-        'FplLeagueTable' {
-            $Hashtable['LeagueName'] = $LeagueName
-            $Hashtable['LeagueId'] = $Hashtable['League']
-            $Hashtable.Remove('League')
-            $Hashtable['TeamId'] = $Hashtable['Team']
-            $Hashtable.Remove('Team')
-        }
-        'FplTeam' {
-            $Hashtable['Bank'] = $Hashtable['Bank'] / 10
-            $Hashtable['Value'] = $Hashtable['Value'] / 10
-            if ($Hashtable['FavouriteClub']) {
-                $Hashtable['FavouriteClub'] = $TeamHash[$Hashtable['FavouriteClub']]
+            'FplLeagueTable' {
+                $Hashtable['LeagueName'] = $LeagueName
+                $Hashtable['LeagueId'] = $Hashtable['League']
+                $Hashtable.Remove('League')
+                $Hashtable['TeamId'] = $Hashtable['Team']
+                $Hashtable.Remove('Team')
             }
-            $Hashtable['TeamId'] = $Hashtable['Id']
-            $Hashtable.Remove('Id')
-            $Hashtable['PlayerId'] = $Hashtable['Player']
-            $Hashtable.Remove('Player')
-        }
-        'FplLeague' {
-            $Hashtable['LeagueId'] = $Hashtable['Id']
-            $Hashtable.Remove('Id')
-            $Hashtable['LeagueType'] = switch ($Hashtable['LeagueType']) {
-                'c' {'Public'}
-                's' {'Global'}
-                'x' {'Private'}
+            'FplTeam' {
+                $Hashtable['Bank'] = $Hashtable['Bank'] / 10
+                $Hashtable['Value'] = $Hashtable['Value'] / 10
+                if ($Hashtable['FavouriteClub']) {
+                    $Hashtable['FavouriteClub'] = $TeamHash[$Hashtable['FavouriteClub']]
+                }
+                $Hashtable['TeamId'] = $Hashtable['Id']
+                $Hashtable.Remove('Id')
+                $Hashtable['PlayerId'] = $Hashtable['Player']
+                $Hashtable.Remove('Player')
             }
-            $Hashtable['Scoring'] = switch ($Hashtable['Scoring']) {
-                'c' {'Classic'}
-                'h' {'H2H'}
+            'FplLeague' {
+                $Hashtable['LeagueId'] = $Hashtable['Id']
+                $Hashtable.Remove('Id')
+                $Hashtable['LeagueType'] = switch ($Hashtable['LeagueType']) {
+                    'c' {'Public'}
+                    's' {'Global'}
+                    'x' {'Private'}
+                }
+                $Hashtable['Scoring'] = switch ($Hashtable['Scoring']) {
+                    'c' {'Classic'}
+                    'h' {'H2H'}
+                }
             }
-        }
-        'FplTeamPlayer' {
-            $Hashtable['PlayerId'] = $Hashtable['Element']
-            $Hashtable.Remove('Element')
-            if ($Hashtable.position -le 11) {
-                $Hashtable['PlayingStatus'] = 'Starting'
-            }
-            else {
-                $Hashtable['PlayingStatus'] = 'Substitute'
-            }
+            'FplTeamPlayer' {
+                $Hashtable['PlayerId'] = $Hashtable['Element']
+                $Hashtable.Remove('Element')
+                if ($Hashtable.position -le 11) {
+                    $Hashtable['PlayingStatus'] = 'Starting'
+                }
+                else {
+                    $Hashtable['PlayingStatus'] = 'Substitute'
+                }
 
-            $CurrentPlayer = $Players.Where{$_.PlayerId -eq $Hashtable['PlayerId']}
-            foreach ($Property in (Get-Member -InputObject $CurrentPlayer[0] -MemberType 'NoteProperty').Name) {
-                $Hashtable[$Property] = $CurrentPlayer.$Property
-            }
-            $Hashtable['Points'] = $CurrentPlayer.GameweekPoints * $Hashtable['Multiplier']
-            $Hashtable.Remove('Multiplier')
+                $CurrentPlayer = $Players.Where{$_.PlayerId -eq $Hashtable['PlayerId']}
+                foreach ($Property in (Get-Member -InputObject $CurrentPlayer[0] -MemberType 'NoteProperty').Name) {
+                    $Hashtable[$Property] = $CurrentPlayer.$Property
+                }
+                $Hashtable['Points'] = $CurrentPlayer.GameweekPoints * $Hashtable['Multiplier']
+                $Hashtable.Remove('Multiplier')
 
+            }
+            'FplLineup' {
+                $Hashtable['PlayerId'] = $Hashtable['Element']
+                $Hashtable.Remove('Element')
+                $Hashtable['PositionNumber'] = $Hashtable['Position']
+                if ($Hashtable.position -le 11) {
+                    $Hashtable['PlayingStatus'] = 'Starting'
+                }
+                else {
+                    $Hashtable['PlayingStatus'] = 'Substitute'
+                }
+                $CurrentPlayer = $Players.Where{$_.PlayerId -eq $Hashtable['PlayerId']}
+                foreach ($Property in 'Name', 'Position', 'Club') {
+                    $Hashtable[$Property] = $CurrentPlayer.$Property
+                }
+                $Hashtable['SellingPrice'] = $Hashtable['SellingPrice'] / 10
+            }
         }
-        'FplLineup' {
-            $Hashtable['PlayerId'] = $Hashtable['Element']
-            $Hashtable.Remove('Element')
-            $Hashtable['PositionNumber'] = $Hashtable['Position']
-            if ($Hashtable.position -le 11) {
-                $Hashtable['PlayingStatus'] = 'Starting'
-            }
-            else {
-                $Hashtable['PlayingStatus'] = 'Substitute'
-            }
-            $CurrentPlayer = $Players.Where{$_.PlayerId -eq $Hashtable['PlayerId']}
-            foreach ($Property in 'Name', 'Position', 'Club') {
-                $Hashtable[$Property] = $CurrentPlayer.$Property
-            }
-            $Hashtable['SellingPrice'] = $Hashtable['SellingPrice'] / 10
-        }
+        $Hashtable['PsTypeName'] = $Type
+        [pscustomobject]$Hashtable
     }
-    $Hashtable['PsTypeName'] = $Type
-    [pscustomobject]$Hashtable
-}
 }

--- a/PSFPL/Private/ConvertTo-FplObject.ps1
+++ b/PSFPL/Private/ConvertTo-FplObject.ps1
@@ -58,7 +58,7 @@ function ConvertTo-FplObject {
     $TextInfo = (Get-Culture).TextInfo
     foreach ($Object in $InputObject) {
         $Hashtable = [ordered]@{}
-        $Object.psobject.properties | Foreach-Object {
+        $Object.psobject.properties | ForEach-Object {
             $Name = $TextInfo.ToTitleCase($_.Name) -replace '_' -replace 'Team', 'Club' -replace 'Entry', 'Team' -replace 'Event', 'Gameweek'
             $Value = if ($_.Value -is [string]) {
                 $DiacriticName = [Text.Encoding]::UTF8.GetString([Text.Encoding]::GetEncoding('ISO-8859-1').GetBytes($_.Value))
@@ -70,123 +70,124 @@ function ConvertTo-FplObject {
             $Hashtable[$Name] = $Value
         }
 
-        switch ($Type) {
-            'FplPlayer' {
-                $Hashtable['PlayerId'] = $Hashtable['Id']
-                $Hashtable.Remove('Id')
-                $Hashtable['Position'] = $PositionHash[$Object.element_type]
-                $Hashtable['ClubId'] = $Hashtable['Club']
-                $Hashtable['Club'] = $TeamHash[$Hashtable['Club']]
-                $Hashtable['Price'] = $Object.now_cost / 10
+    switch ($Type) {
+        'FplPlayer' {
+            $Hashtable['PlayerId'] = $Hashtable['Id']
+            $Hashtable.Remove('Id')
+            $Hashtable['Name'] = $Hashtable['WebName']
+            $Hashtable['Position'] = $PositionHash[$Object.element_type]
+            $Hashtable['ClubId'] = $Hashtable['Club']
+            $Hashtable['Club'] = $TeamHash[$Hashtable['Club']]
+            $Hashtable['Price'] = $Object.now_cost / 10
+        }
+        'FplGameweek' {
+            $Hashtable['Gameweek'] = $Hashtable['Id']
+            $Hashtable.Remove('Id')
+            $Hashtable['DeadlineTime'] = Get-Date $Object.deadline_time
+        }
+        'FplFixture' {
+            $Hashtable['FixtureId'] = $Hashtable['Id']
+            $Hashtable.Remove('Id')
+            $Hashtable['DeadlineTime'] = try {
+                Get-Date $Object.deadline_time
             }
-            'FplGameweek' {
-                $Hashtable['Gameweek'] = $Hashtable['Id']
-                $Hashtable.Remove('Id')
-                $Hashtable['DeadlineTime'] = Get-Date $Object.deadline_time
+            catch {
+                'tbc'
             }
-            'FplFixture' {
-                $Hashtable['FixtureId'] = $Hashtable['Id']
-                $Hashtable.Remove('Id')
-                $Hashtable['DeadlineTime'] = try {
-                    Get-Date $Object.deadline_time
-                }
-                catch {
-                    'tbc'
-                }
-                $HashTable['KickoffTime'] = try {
-                    Get-Date $Object.kickoff_time
-                }
-                catch {
-                    'tbc'
-                }
-                if (-not $Hashtable['Gameweek']) {
-                    $Hashtable['Gameweek'] = 'tbc'
-                }
-                $Hashtable['ClubA'] = $TeamHash[$Object.team_a]
-                $Hashtable['ClubH'] = $TeamHash[$Object.team_h]
-                $Hashtable['Stats'] = foreach ($Stat in $Hashtable['Stats']) {
-                    $StatType = $TextInfo.ToTitleCase($Stat.PSObject.Properties.Name)
-                    foreach ($Letter in 'a', 'h') {
-                        $Club = 'Club{0}' -f $Letter.ToUpper()
-                        foreach ($Item in $Stat.$StatType.$Letter) {
-                            [pscustomobject]@{
-                                'PlayerId'   = $Item.element
-                                'PlayerName' = $PlayerHash[$Item.element]
-                                'StatType'   = $StatType -replace '_'
-                                'StatValue'  = $Item.value
-                                'ClubName'   = $Hashtable[$club]
-                            }
+            $HashTable['KickoffTime'] = try {
+                Get-Date $Object.kickoff_time
+            }
+            catch {
+                'tbc'
+            }
+            if (-not $Hashtable['Gameweek']) {
+                $Hashtable['Gameweek'] = 'tbc'
+            }
+            $Hashtable['ClubA'] = $TeamHash[$Object.team_a]
+            $Hashtable['ClubH'] = $TeamHash[$Object.team_h]
+            $Hashtable['Stats'] = foreach ($Stat in $Hashtable['Stats']) {
+                $StatType = $TextInfo.ToTitleCase($Stat.PSObject.Properties.Name)
+                foreach ($Letter in 'a', 'h') {
+                    $Club = 'Club{0}' -f $Letter.ToUpper()
+                    foreach ($Item in $Stat.$StatType.$Letter) {
+                        [pscustomobject]@{
+                            'PlayerId'   = $Item.element
+                            'PlayerName' = $PlayerHash[$Item.element]
+                            'StatType'   = $StatType -replace '_'
+                            'StatValue'  = $Item.value
+                            'ClubName'   = $Hashtable[$club]
                         }
                     }
                 }
             }
-            'FplLeagueTable' {
-                $Hashtable['LeagueName'] = $LeagueName
-                $Hashtable['LeagueId'] = $Hashtable['League']
-                $Hashtable.Remove('League')
-                $Hashtable['TeamId'] = $Hashtable['Team']
-                $Hashtable.Remove('Team')
+        }
+        'FplLeagueTable' {
+            $Hashtable['LeagueName'] = $LeagueName
+            $Hashtable['LeagueId'] = $Hashtable['League']
+            $Hashtable.Remove('League')
+            $Hashtable['TeamId'] = $Hashtable['Team']
+            $Hashtable.Remove('Team')
+        }
+        'FplTeam' {
+            $Hashtable['Bank'] = $Hashtable['Bank'] / 10
+            $Hashtable['Value'] = $Hashtable['Value'] / 10
+            if ($Hashtable['FavouriteClub']) {
+                $Hashtable['FavouriteClub'] = $TeamHash[$Hashtable['FavouriteClub']]
             }
-            'FplTeam' {
-                $Hashtable['Bank'] = $Hashtable['Bank'] / 10
-                $Hashtable['Value'] = $Hashtable['Value'] / 10
-                if ($Hashtable['FavouriteClub']) {
-                    $Hashtable['FavouriteClub'] = $TeamHash[$Hashtable['FavouriteClub']]
-                }
-                $Hashtable['TeamId'] = $Hashtable['Id']
-                $Hashtable.Remove('Id')
-                $Hashtable['PlayerId'] = $Hashtable['Player']
-                $Hashtable.Remove('Player')
+            $Hashtable['TeamId'] = $Hashtable['Id']
+            $Hashtable.Remove('Id')
+            $Hashtable['PlayerId'] = $Hashtable['Player']
+            $Hashtable.Remove('Player')
+        }
+        'FplLeague' {
+            $Hashtable['LeagueId'] = $Hashtable['Id']
+            $Hashtable.Remove('Id')
+            $Hashtable['LeagueType'] = switch ($Hashtable['LeagueType']) {
+                'c' {'Public'}
+                's' {'Global'}
+                'x' {'Private'}
             }
-            'FplLeague' {
-                $Hashtable['LeagueId'] = $Hashtable['Id']
-                $Hashtable.Remove('Id')
-                $Hashtable['LeagueType'] = switch ($Hashtable['LeagueType']) {
-                    'c' {'Public'}
-                    's' {'Global'}
-                    'x' {'Private'}
-                }
-                $Hashtable['Scoring'] = switch ($Hashtable['Scoring']) {
-                    'c' {'Classic'}
-                    'h' {'H2H'}
-                }
-            }
-            'FplTeamPlayer' {
-                $Hashtable['PlayerId'] = $Hashtable['Element']
-                $Hashtable.Remove('Element')
-                if ($Hashtable.position -le 11) {
-                    $Hashtable['PlayingStatus'] = 'Starting'
-                }
-                else {
-                    $Hashtable['PlayingStatus'] = 'Substitute'
-                }
-
-                $CurrentPlayer = $Players.Where{$_.PlayerId -eq $Hashtable['PlayerId']}
-                foreach ($Property in (Get-Member -InputObject $CurrentPlayer[0] -MemberType 'NoteProperty').Name) {
-                    $Hashtable[$Property] = $CurrentPlayer.$Property
-                }
-                $Hashtable['Points'] = $CurrentPlayer.GameweekPoints * $Hashtable['Multiplier']
-                $Hashtable.Remove('Multiplier')
-
-            }
-            'FplLineup' {
-                $Hashtable['PlayerId'] = $Hashtable['Element']
-                $Hashtable.Remove('Element')
-                $Hashtable['PositionNumber'] = $Hashtable['Position']
-                if ($Hashtable.position -le 11) {
-                    $Hashtable['PlayingStatus'] = 'Starting'
-                }
-                else {
-                    $Hashtable['PlayingStatus'] = 'Substitute'
-                }
-                $CurrentPlayer = $Players.Where{$_.PlayerId -eq $Hashtable['PlayerId']}
-                foreach ($Property in 'WebName', 'Position', 'Club') {
-                    $Hashtable[$Property] = $CurrentPlayer.$Property
-                }
-                $Hashtable['SellingPrice'] = $Hashtable['SellingPrice'] / 10
+            $Hashtable['Scoring'] = switch ($Hashtable['Scoring']) {
+                'c' {'Classic'}
+                'h' {'H2H'}
             }
         }
-        $Hashtable['PsTypeName'] = $Type
-        [pscustomobject]$Hashtable
+        'FplTeamPlayer' {
+            $Hashtable['PlayerId'] = $Hashtable['Element']
+            $Hashtable.Remove('Element')
+            if ($Hashtable.position -le 11) {
+                $Hashtable['PlayingStatus'] = 'Starting'
+            }
+            else {
+                $Hashtable['PlayingStatus'] = 'Substitute'
+            }
+
+            $CurrentPlayer = $Players.Where{$_.PlayerId -eq $Hashtable['PlayerId']}
+            foreach ($Property in (Get-Member -InputObject $CurrentPlayer[0] -MemberType 'NoteProperty').Name) {
+                $Hashtable[$Property] = $CurrentPlayer.$Property
+            }
+            $Hashtable['Points'] = $CurrentPlayer.GameweekPoints * $Hashtable['Multiplier']
+            $Hashtable.Remove('Multiplier')
+
+        }
+        'FplLineup' {
+            $Hashtable['PlayerId'] = $Hashtable['Element']
+            $Hashtable.Remove('Element')
+            $Hashtable['PositionNumber'] = $Hashtable['Position']
+            if ($Hashtable.position -le 11) {
+                $Hashtable['PlayingStatus'] = 'Starting'
+            }
+            else {
+                $Hashtable['PlayingStatus'] = 'Substitute'
+            }
+            $CurrentPlayer = $Players.Where{$_.PlayerId -eq $Hashtable['PlayerId']}
+            foreach ($Property in 'Name', 'Position', 'Club') {
+                $Hashtable[$Property] = $CurrentPlayer.$Property
+            }
+            $Hashtable['SellingPrice'] = $Hashtable['SellingPrice'] / 10
+        }
     }
+    $Hashtable['PsTypeName'] = $Type
+    [pscustomobject]$Hashtable
+}
 }

--- a/PSFPL/Private/Invoke-FplLineupSwap.ps1
+++ b/PSFPL/Private/Invoke-FplLineupSwap.ps1
@@ -31,10 +31,10 @@ function Invoke-FplLineupSwap {
     Add-Type -TypeDefinition $Def
 
     foreach ($Index in 0..($PlayersIn.Count - 1)) {
-        $InPlayer = $Lineup.Where{$_.WebName -eq $PlayersIn[$Index]}[0].psobject.copy()
-        $OutPlayer = $Lineup.Where{$_.WebName -eq $PlayersOut[$Index]}[0].psobject.copy()
+        $InPlayer = $Lineup.Where{$_.Name -eq $PlayersIn[$Index]}[0].psobject.copy()
+        $OutPlayer = $Lineup.Where{$_.Name -eq $PlayersOut[$Index]}[0].psobject.copy()
 
-        foreach ($Property in 'PlayerId', 'Position', 'WebName') {
+        foreach ($Property in 'PlayerId', 'Position', 'Name') {
             $Lineup.Where{$_.PositionNumber -eq $OutPlayer.PositionNumber}[0].$Property = $InPlayer[0].$Property
             $Lineup.Where{$_.PositionNumber -eq $InPlayer.PositionNumber}[0].$Property = $OutPlayer[0].$Property
         }
@@ -44,15 +44,19 @@ function Invoke-FplLineupSwap {
 
         if ((-not $IsSamePosition) -and (-not $AreBothSubstitutes)) {
             $Starters, $Substitutes = $Lineup.Where( {-not $_.IsSub}, 'Split' )
-            $NewStarters = $Starters | Sort-Object {[enum]::GetNames([FPL.Player.Position]).IndexOf($_)}, {[Fpl.Player.Position]$_.Position + $_.PositionNumber}
-            $Lineup = $NewStarters + $Substitutes
-            $Counter = 1
-            $Lineup.Foreach{
-                $_.PositionNumber = $Counter
-                $Counter++
-            }
+            $SortOrder = @(
+                {[enum]::GetNames([FPL.Player.Position]).IndexOf($_)}
+                {[Fpl.Player.Position]$_.Position + $_.PositionNumber}
+            )
+            $NewStarters = $Starters | Sort-Object $SortOrder
+        $Lineup = $NewStarters + $Substitutes
+        $Counter = 1
+        $Lineup.Foreach{
+            $_.PositionNumber = $Counter
+            $Counter++
         }
     }
+}
 
-    $Lineup
+$Lineup
 }

--- a/PSFPL/Private/Invoke-FplLineupSwap.ps1
+++ b/PSFPL/Private/Invoke-FplLineupSwap.ps1
@@ -49,14 +49,14 @@ function Invoke-FplLineupSwap {
                 {[Fpl.Player.Position]$_.Position + $_.PositionNumber}
             )
             $NewStarters = $Starters | Sort-Object $SortOrder
-        $Lineup = $NewStarters + $Substitutes
-        $Counter = 1
-        $Lineup.Foreach{
-            $_.PositionNumber = $Counter
-            $Counter++
+            $Lineup = $NewStarters + $Substitutes
+            $Counter = 1
+            $Lineup.Foreach{
+                $_.PositionNumber = $Counter
+                $Counter++
+            }
         }
     }
-}
 
-$Lineup
+    $Lineup
 }

--- a/PSFPL/Private/Set-FplLineupCaptain.ps1
+++ b/PSFPL/Private/Set-FplLineupCaptain.ps1
@@ -16,7 +16,7 @@ function Set-FplLineupCaptain {
 
     if ($Captain) {
         $Lineup.Where{$_.IsCaptain}[0].IsCaptain = $false
-        $NewCaptain = $Lineup.Where{$_.WebName -eq $Captain}[0]
+        $NewCaptain = $Lineup.Where{$_.Name -eq $Captain}[0]
         if ($NewCaptain.IsSub) {
             Write-Error -Message "You cannot captain a substitute" -ErrorAction 'Stop'
         }
@@ -24,7 +24,7 @@ function Set-FplLineupCaptain {
     }
     if ($ViceCaptain) {
         $Lineup.Where{$_.IsViceCaptain}[0].IsViceCaptain = $false
-        $NewViceCaptain = $Lineup.Where{$_.WebName -eq $ViceCaptain}[0]
+        $NewViceCaptain = $Lineup.Where{$_.Name -eq $ViceCaptain}[0]
         if ($NewViceCaptain.IsSub) {
             Write-Error -Message "You cannot vice captain a substitute" -ErrorAction 'Stop'
         }

--- a/PSFPL/Public/Get-FplGameweek.ps1
+++ b/PSFPL/Public/Get-FplGameweek.ps1
@@ -54,7 +54,7 @@ function Get-FplGameweek {
         $Gameweeks.Where{$_.IsCurrent}
     }
     elseif ($Gameweek -gt 0) {
-        $Gameweeks.Where{$_.Id -eq $Gameweek}
+        $Gameweeks.Where{$_.Gameweek -eq $Gameweek}
     }
     else {
         $Gameweeks

--- a/PSFPL/Public/Get-FplPlayer.ps1
+++ b/PSFPL/Public/Get-FplPlayer.ps1
@@ -80,7 +80,7 @@ function Get-FplPlayer {
     }
     Process {
         $Output = $Players.Where{
-            $_.WebName -match $Name -and
+            $_.Name -match $Name -and
             $_.Position -match $Position -and
             $_.Club -match $Club -and
             $_.Price -le $MaxPrice

--- a/PSFPL/Public/Get-FplTeam.ps1
+++ b/PSFPL/Public/Get-FplTeam.ps1
@@ -28,7 +28,7 @@ function Get-FplTeam {
     )
     process {
         if ($TeamId -gt 0) {
-            $Response = Invoke-RestMethod -Uri "https://fantasy.premierleague.com/drf/entry/$TeamId/" -UseDefaultCredentials
+            $Response = Invoke-RestMethod -Uri "https://fantasy.premierleague.com/drf/entry/$TeamId" -UseDefaultCredentials
             if ($Response -match 'The game is being updated.') {
                 Write-Warning 'The game is being updated. Please try again shortly.'
                 return

--- a/PSFPL/Public/Set-FplLineup.ps1
+++ b/PSFPL/Public/Set-FplLineup.ps1
@@ -79,7 +79,7 @@ function Set-FplLineup {
 
     $PlayerNames = $PlayersIn + $PlayersOut + @($Captain, $ViceCaptain) | Where-Object {$_}
     foreach ($Name in $PlayerNames) {
-        if ($Name -notin $Lineup.WebName) {
+        if ($Name -notin $Lineup.Name) {
             Write-Error -Message "There is no player with the name '$Name' in your team" -ErrorAction 'Stop'
         }
     }

--- a/Tests/Private/ConvertTo-FplObject.Tests.ps1
+++ b/Tests/Private/ConvertTo-FplObject.Tests.ps1
@@ -28,421 +28,421 @@ InModuleScope 'PSFPL' {
             }
             It 'outputs an FplPlayer object' {
                 $Result.PSTypeNames | Should -Contain 'FplPlayer'
+            }
+            It 'converts diacritic characters' {
+                $Result.Name | Should -Be 'Bellerin'
+            }
+            It 'converts property names to Pascal Case' {
+                $Result.psobject.properties.Name | Should -Be @('WebName', 'ElementType', 'Club', 'NowCost', 'PlayerId', 'Name', 'Position', 'ClubId', 'Price')
+            }
+            It 'converts element type to position' {
+                $Result.Position | Should -Be 'Defender'
+            }
+            It 'converts team ID to club name' {
+                $Result.Club | Should -Be 'Arsenal'
+            }
+            It 'converts ID to Player ID' {
+                $Result.Id | Should -BeNullOrEmpty
+                $Result.PlayerId | Should -Be 4
+            }
         }
-        It 'converts diacritic characters' {
-            $Result.Name | Should -Be 'Bellerin'
-    }
-    It 'converts property names to Pascal Case' {
-        $Result.psobject.properties.Name | Should -Be @('WebName', 'ElementType', 'Club', 'NowCost', 'PlayerId', 'Name', 'Position', 'ClubId', 'Price')
-}
-It 'converts element type to position' {
-    $Result.Position | Should -Be 'Defender'
-}
-It 'converts team ID to club name' {
-    $Result.Club | Should -Be 'Arsenal'
-}
-It 'converts ID to Player ID' {
-    $Result.Id | Should -BeNullOrEmpty
-$Result.PlayerId | Should -Be 4
-}
-}
-Context 'FplGameweek type' {
-    BeforeAll {
-        $Object = [PSCustomObject]@{
-            id                  = 1
-            deadline_time       = '08/10/2018 18:00:00'
-            average_entry_score = 53
+        Context 'FplGameweek type' {
+            BeforeAll {
+                $Object = [PSCustomObject]@{
+                    id                  = 1
+                    deadline_time       = '08/10/2018 18:00:00'
+                    average_entry_score = 53
+                }
+                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplGameweek'
+            }
+            It 'outputs an FplGameweek object' {
+                $Result.PSTypeNames | Should -Contain 'FplGameweek'
+            }
+            It 'converts "Entry" in a property name to "Team"' {
+                $Result.psobject.properties.name | Should -Contain 'AverageTeamScore'
+            }
+            It 'converts DeadlineTime to a DateTime object' {
+                $Result.DeadlineTime | Should -BeOfType [DateTime]
+            }
+            It 'renames the Id property to Gameweek' {
+                $Result.Id | Should -BeNullOrEmpty
+                $Result.Gameweek | Should -BeExactly 1
+            }
         }
-        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplGameweek'
-    }
-    It 'outputs an FplGameweek object' {
-        $Result.PSTypeNames | Should -Contain 'FplGameweek'
-}
-It 'converts "Entry" in a property name to "Team"' {
-    $Result.psobject.properties.name | Should -Contain 'AverageTeamScore'
-}
-It 'converts DeadlineTime to a DateTime object' {
-    $Result.DeadlineTime | Should -BeOfType [DateTime]
-}
-It 'renames the Id property to Gameweek' {
-    $Result.Id | Should -BeNullOrEmpty
-$Result.Gameweek | Should -BeExactly 1
-}
-}
-Context 'FplFixture type' {
-    BeforeAll {
-        $Object = [PSCustomObject]@{
-            event         = 1
-            deadline_time = '2018-08-10T18:00:00Z'
-            kickoff_time  = '2018-08-10T19:00:00Z'
-            team_a        = 1
-            team_h        = 2
-            id            = 3
-            stats         = @(
-                [pscustomobject]@{
-                    goals_scored = [pscustomobject]@{
-                        a = @(
-                            [pscustomobject]@{
-                                value   = 1
-                                element = 234
+        Context 'FplFixture type' {
+            BeforeAll {
+                $Object = [PSCustomObject]@{
+                    event         = 1
+                    deadline_time = '2018-08-10T18:00:00Z'
+                    kickoff_time  = '2018-08-10T19:00:00Z'
+                    team_a        = 1
+                    team_h        = 2
+                    id            = 3
+                    stats         = @(
+                        [pscustomobject]@{
+                            goals_scored = [pscustomobject]@{
+                                a = @(
+                                    [pscustomobject]@{
+                                        value   = 1
+                                        element = 234
+                                    }
+                                )
+                                h = @(
+                                    [pscustomobject]@{
+                                        value   = 1
+                                        element = 286
+                                    },
+                                    [pscustomobject]@{
+                                        value   = 1
+                                        element = 302
+                                    }
+                                )
                             }
-                        )
-                        h = @(
-                            [pscustomobject]@{
-                                value   = 1
-                                element = 286
-                            },
-                            [pscustomobject]@{
-                                value   = 1
-                                element = 302
-                            }
-                        )
-                    }
-                }
-            )
-        },
-        [PSCustomObject]@{
-            event         = 2
-            deadline_time = $null
-            kickoff_time  = $null
-            gameweek      = $null
-            team_a        = 3
-            team_h        = 4
-            id            = 5
-            stats         = @(
-                [pscustomobject]@{
-                    goals_scored = [pscustomobject]@{
-                        a = @(
-                            [pscustomobject]@{
-                                value   = 1
-                                element = 234
-                            }
-                        )
-                        h = @(
-                            [pscustomobject]@{
-                                value   = 1
-                                element = 286
-                            },
-                            [pscustomobject]@{
-                                value   = 1
-                                element = 302
-                            }
-                        )
-                    }
-                }
-            )
-        }
-
-        Mock Get-FplClubId {
-            @{
-                1 = 'Leicester'
-                2 = 'Man Utd'
-            }
-        }
-
-        Mock Get-FplElementId {
-            @{
-                234 = 'Vardy'
-                286 = 'Shaw'
-                302 = 'Pogba'
-            }
-        }
-
-        $Result = ConvertTo-FplObject -InputObject $Object[0] -Type 'FplFixture'
-    }
-    It 'changes "Event" to "Gameweek" in property names' {
-        $Result.psobject.properties.Name | Should -Contain 'Gameweek'
-    $Result.psobject.properties.Name | Should -Not -Contain 'Event'
-}
-It 'converts DeadlineTime to a DateTime object' {
-    $Result.DeadlineTime | Should -BeOfType [DateTime]
-}
-It 'converts KickoffTime to a DateTime object' {
-    $Result.KickoffTime | Should -BeOfType [DateTime]
-}
-It 'converts team ID to name' {
-    $Result.Stats[0].ClubName | Should -Be 'Leicester'
-$Result.Stats[1].ClubName | Should -Be 'Man Utd'
-}
-It 'flattens the nested stats property' {
-    $Result.Stats[0].psobject.Properties.Name | Should -Be  @(
-        'PlayerId',
-        'PlayerName',
-        'StatType',
-        'StatValue',
-        'ClubName'
-    )
-}
-It 'converts stats player ID to name' {
-    $Result.Stats.PlayerName | Should -Be @(
-        'Vardy',
-        'Shaw',
-        'Pogba'
-    )
-}
-It 'removes underscores from stat types' {
-    $Result.Stats.StatType | Should -Not -Match '_'
-}
-It 'converts stats club ID to name' {
-    $Result.Stats.ClubName | Should -Be @(
-        'Leicester',
-        'Man Utd',
-        'Man Utd'
-    )
-}
-It 'converts ID to Fixture ID' {
-    $Result.Id | Should -BeNullOrEmpty
-$Result.FixtureId | Should -Be 3
-}
-It 'handles null values for deadline, kickoff and gameweek' {
-    $Result = ConvertTo-FplObject -InputObject $Object[1] -Type 'FplFixture'
-    $Result.Gameweek, $Result.DeadlineTime, $Result.KickoffTime | ForEach-Object {
-        $_ | Should -Be 'tbc'
-}
-}
-}
-Context 'FplLeagueTable type' {
-    BeforeAll {
-        $Object = @(
-            [PSCustomObject]@{
-                league    = [PSCustomObject]@{
-                    name = 'MyCustomLeague'
-                }
-                standings = [PSCustomObject]@{
-                    has_next = $false
-                    results  = [PSCustomObject]@{
-                        league = 12345
-                        entry  = 54321
-                    }
-                }
-            },
-            [PSCustomObject]@{
-                league    = [PSCustomObject]@{
-                    name = 'MyCustomLeague'
-                }
-                standings = [PSCustomObject]@{
-                    has_next = $false
-                    results  = [PSCustomObject]@{
-                        league = 12345
-                        entry  = 65432
-                    }
-                }
-            }
-        )
-
-        $Results = ConvertTo-FplObject -InputObject $Object -Type 'FplLeagueTable'
-    }
-    It 'adds the LeagueName property' {
-        $Results | ForEach-Object {$_.LeagueName | Should -Be 'MyCustomLeague'}
-}
-It 'renames the League property to LeagueId' {
-    $Results | ForEach-Object {$_.League | Should -BeNullOrEmpty}
-$Results.LeagueId | Should -Contain 12345
-}
-It 'renames the Team property to TeamId' {
-    $Results | ForEach-Object {$_.Team | Should -BeNullOrEmpty}
-$Results.TeamId | Should -Be 54321, 65432
-}
-}
-Context 'FplTeam type' {
-    BeforeAll {
-        Mock Get-FplClubId {
-            @{
-                6 = 'Chelsea'
-            }
-        }
-        $Object = [PSCustomObject]@{
-            bank          = 13
-            value         = 1013
-            favouriteteam = 6
-            id            = 123456
-            player        = 987654321
-        }
-        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplTeam'
-    }
-    It 'divides the bank property by 10' {
-        $Result.Bank | Should -Be 1.3
-}
-It 'divides the value property by 10' {
-    $Result.Value | Should -Be 101.3
-}
-It 'replaces favourite team ID with name' {
-    $Result.FavouriteClub | Should -Be 'Chelsea'
-}
-It 'renames the Id property to TeamId' {
-    $Result.Id | Should -BeNullOrEmpty
-$Result.TeamId | Should -Be 123456
-}
-It 'renames the Player property to PlayerId' {
-    $Result.Player | Should -BeNullOrEmpty
-$Result.PlayerId | Should -Be 987654321
-}
-}
-Context 'FplLeague' {
-    BeforeAll {
-        $Object = [PSCustomObject]@{
-            classic = [PSCustomObject]@{
-                Name        = 'Classic League'
-                league_type = 'c'
-                _scoring    = 'c'
-                id          = 1
-            }
-            h2h     = @(
-                [PSCustomObject]@{
-                    Name = 'cup'
-                    id   = 2
+                        }
+                    )
                 },
                 [PSCustomObject]@{
-                    Name        = 'H2H League'
-                    league_type = 's'
-                    _scoring    = 'h'
-                    id          = 3
+                    event         = 2
+                    deadline_time = $null
+                    kickoff_time  = $null
+                    gameweek      = $null
+                    team_a        = 3
+                    team_h        = 4
+                    id            = 5
+                    stats         = @(
+                        [pscustomobject]@{
+                            goals_scored = [pscustomobject]@{
+                                a = @(
+                                    [pscustomobject]@{
+                                        value   = 1
+                                        element = 234
+                                    }
+                                )
+                                h = @(
+                                    [pscustomobject]@{
+                                        value   = 1
+                                        element = 286
+                                    },
+                                    [pscustomobject]@{
+                                        value   = 1
+                                        element = 302
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+
+                Mock Get-FplClubId {
+                    @{
+                        1 = 'Leicester'
+                        2 = 'Man Utd'
+                    }
+                }
+
+                Mock Get-FplElementId {
+                    @{
+                        234 = 'Vardy'
+                        286 = 'Shaw'
+                        302 = 'Pogba'
+                    }
+                }
+
+                $Result = ConvertTo-FplObject -InputObject $Object[0] -Type 'FplFixture'
+            }
+            It 'changes "Event" to "Gameweek" in property names' {
+                $Result.psobject.properties.Name | Should -Contain 'Gameweek'
+                $Result.psobject.properties.Name | Should -Not -Contain 'Event'
+            }
+            It 'converts DeadlineTime to a DateTime object' {
+                $Result.DeadlineTime | Should -BeOfType [DateTime]
+            }
+            It 'converts KickoffTime to a DateTime object' {
+                $Result.KickoffTime | Should -BeOfType [DateTime]
+            }
+            It 'converts team ID to name' {
+                $Result.Stats[0].ClubName | Should -Be 'Leicester'
+                $Result.Stats[1].ClubName | Should -Be 'Man Utd'
+            }
+            It 'flattens the nested stats property' {
+                $Result.Stats[0].psobject.Properties.Name | Should -Be  @(
+                    'PlayerId',
+                    'PlayerName',
+                    'StatType',
+                    'StatValue',
+                    'ClubName'
+                )
+            }
+            It 'converts stats player ID to name' {
+                $Result.Stats.PlayerName | Should -Be @(
+                    'Vardy',
+                    'Shaw',
+                    'Pogba'
+                )
+            }
+            It 'removes underscores from stat types' {
+                $Result.Stats.StatType | Should -Not -Match '_'
+            }
+            It 'converts stats club ID to name' {
+                $Result.Stats.ClubName | Should -Be @(
+                    'Leicester',
+                    'Man Utd',
+                    'Man Utd'
+                )
+            }
+            It 'converts ID to Fixture ID' {
+                $Result.Id | Should -BeNullOrEmpty
+                $Result.FixtureId | Should -Be 3
+            }
+            It 'handles null values for deadline, kickoff and gameweek' {
+                $Result = ConvertTo-FplObject -InputObject $Object[1] -Type 'FplFixture'
+                $Result.Gameweek, $Result.DeadlineTime, $Result.KickoffTime | ForEach-Object {
+                    $_ | Should -Be 'tbc'
+                }
+            }
+        }
+        Context 'FplLeagueTable type' {
+            BeforeAll {
+                $Object = @(
+                    [PSCustomObject]@{
+                        league    = [PSCustomObject]@{
+                            name = 'MyCustomLeague'
+                        }
+                        standings = [PSCustomObject]@{
+                            has_next = $false
+                            results  = [PSCustomObject]@{
+                                league = 12345
+                                entry  = 54321
+                            }
+                        }
+                    },
+                    [PSCustomObject]@{
+                        league    = [PSCustomObject]@{
+                            name = 'MyCustomLeague'
+                        }
+                        standings = [PSCustomObject]@{
+                            has_next = $false
+                            results  = [PSCustomObject]@{
+                                league = 12345
+                                entry  = 65432
+                            }
+                        }
+                    }
+                )
+
+                $Results = ConvertTo-FplObject -InputObject $Object -Type 'FplLeagueTable'
+            }
+            It 'adds the LeagueName property' {
+                $Results | ForEach-Object {$_.LeagueName | Should -Be 'MyCustomLeague'}
+            }
+            It 'renames the League property to LeagueId' {
+                $Results | ForEach-Object {$_.League | Should -BeNullOrEmpty}
+                $Results.LeagueId | Should -Contain 12345
+            }
+            It 'renames the Team property to TeamId' {
+                $Results | ForEach-Object {$_.Team | Should -BeNullOrEmpty}
+                $Results.TeamId | Should -Be 54321, 65432
+            }
+        }
+        Context 'FplTeam type' {
+            BeforeAll {
+                Mock Get-FplClubId {
+                    @{
+                        6 = 'Chelsea'
+                    }
+                }
+                $Object = [PSCustomObject]@{
+                    bank          = 13
+                    value         = 1013
+                    favouriteteam = 6
+                    id            = 123456
+                    player        = 987654321
+                }
+                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplTeam'
+            }
+            It 'divides the bank property by 10' {
+                $Result.Bank | Should -Be 1.3
+            }
+            It 'divides the value property by 10' {
+                $Result.Value | Should -Be 101.3
+            }
+            It 'replaces favourite team ID with name' {
+                $Result.FavouriteClub | Should -Be 'Chelsea'
+            }
+            It 'renames the Id property to TeamId' {
+                $Result.Id | Should -BeNullOrEmpty
+                $Result.TeamId | Should -Be 123456
+            }
+            It 'renames the Player property to PlayerId' {
+                $Result.Player | Should -BeNullOrEmpty
+                $Result.PlayerId | Should -Be 987654321
+            }
+        }
+        Context 'FplLeague' {
+            BeforeAll {
+                $Object = [PSCustomObject]@{
+                    classic = [PSCustomObject]@{
+                        Name        = 'Classic League'
+                        league_type = 'c'
+                        _scoring    = 'c'
+                        id          = 1
+                    }
+                    h2h     = @(
+                        [PSCustomObject]@{
+                            Name = 'cup'
+                            id   = 2
+                        },
+                        [PSCustomObject]@{
+                            Name        = 'H2H League'
+                            league_type = 's'
+                            _scoring    = 'h'
+                            id          = 3
+                        },
+                        [PSCustomObject]@{
+                            Name        = 'Classic League 2'
+                            league_type = 'x'
+                            _scoring    = 'c'
+                            id          = 4
+                        }
+                    )
+                }
+
+                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplLeague'
+            }
+            It 'outputs an FPLLeague object' {
+                $Result[0].PSTypeNames | Should -Contain 'FplLeague'
+            }
+            It 'adds the classic and h2h leagues together leaving out the cup' {
+                $Result.Name | Should -Be 'Classic League', 'H2H League', 'Classic League 2'
+            }
+            It 'converts the LeagueType parameter' {
+                $Result.LeagueType | Should -Be 'Public', 'Global', 'Private'
+            }
+            It 'converts the Scoring parameter' {
+                $Result.Scoring | Should -Be 'Classic', 'H2H', 'Classic'
+            }
+            It 'converts ID to League ID' {
+                $Result.foreach{$_.Id | Should -BeNullOrEmpty}
+                $Result.LeagueId | Should -Be 1, 3, 4
+            }
+        }
+        Context 'FplTeamPlayer' {
+            BeforeAll {
+                Mock Get-FplPlayer {
+                    [PSCustomObject]@{
+                        Name           = 'Hazard'
+                        PlayerId       = 122
+                        Club           = 'Chelsea'
+                        Position       = 'Midfielder'
+                        GameweekPoints = 8
+                    },
+                    [PSCustomObject]@{
+                        Name           = 'Alonso'
+                        PlayerId       = 115
+                        Club           = 'Chelsea'
+                        Position       = 'Defender'
+                        GameweekPoints = 2
+                    }
+                }
+
+                $Object = [PSCustomObject]@{
+                    element         = 122
+                    position        = 1
+                    is_captain      = $true
+                    is_vice_captain = $false
+                    multiplier      = 2
                 },
                 [PSCustomObject]@{
-                    Name        = 'Classic League 2'
-                    league_type = 'x'
-                    _scoring    = 'c'
-                    id          = 4
+                    element         = 115
+                    position        = 12
+                    is_captain      = $false
+                    is_vice_captain = $false
+                    multiplier      = 1
                 }
-            )
-        }
 
-        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplLeague'
-    }
-    It 'outputs an FPLLeague object' {
-        $Result[0].PSTypeNames | Should -Contain 'FplLeague'
-}
-It 'adds the classic and h2h leagues together leaving out the cup' {
-    $Result.Name | Should -Be 'Classic League', 'H2H League', 'Classic League 2'
-}
-It 'converts the LeagueType parameter' {
-    $Result.LeagueType | Should -Be 'Public', 'Global', 'Private'
-}
-It 'converts the Scoring parameter' {
-    $Result.Scoring | Should -Be 'Classic', 'H2H', 'Classic'
-}
-It 'converts ID to League ID' {
-    $Result.foreach{$_.Id | Should -BeNullOrEmpty}
-$Result.LeagueId | Should -Be 1, 3, 4
-}
-}
-Context 'FplTeamPlayer' {
-    BeforeAll {
-        Mock Get-FplPlayer {
-            [PSCustomObject]@{
-                Name           = 'Hazard'
-                PlayerId       = 122
-                Club           = 'Chelsea'
-                Position       = 'Midfielder'
-                GameweekPoints = 8
-            },
-            [PSCustomObject]@{
-                Name           = 'Alonso'
-                PlayerId       = 115
-                Club           = 'Chelsea'
-                Position       = 'Defender'
-                GameweekPoints = 2
+                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplTeamPlayer'
+            }
+            It 'outputs an FPLTeamPlayer object' {
+                $Result[0].PSTypeNames | Should -Contain 'FplTeamPlayer'
+            }
+            It 'renames the Element property to PlayerId' {
+                $Result[0].Element | Should -BeNullOrEmpty
+                $Result.PlayerId | Should -Be 122, 115
+            }
+            It 'sets the PlayingStatus property' {
+                $Result[0].PlayingStatus | Should -Be 'Starting'
+                $Result[1].PlayingStatus | Should -Be 'Substitute'
+            }
+            It 'transfers properties from the FplPlayer object' {
+                $Result.Name | Should -Be 'Hazard', 'Alonso'
+                $Result.Club | Should -Be 'Chelsea', 'Chelsea'
+                $Result.Position | Should -Be 'Midfielder', 'Defender'
+            }
+            It 'calculates captain points for only the captain' {
+                $Result.Points | Should -Be 16, 2
             }
         }
+        Context 'FplLineup' {
+            BeforeAll {
+                Mock Get-FplPlayer {
+                    [PSCustomObject]@{
+                        Name           = 'Hazard'
+                        PlayerId       = 122
+                        Club           = 'Chelsea'
+                        Position       = 'Midfielder'
+                        GameweekPoints = 8
+                    },
+                    [PSCustomObject]@{
+                        Name           = 'Alonso'
+                        PlayerId       = 115
+                        Club           = 'Chelsea'
+                        Position       = 'Defender'
+                        GameweekPoints = 2
+                    }
+                }
 
-        $Object = [PSCustomObject]@{
-            element         = 122
-            position        = 1
-            is_captain      = $true
-            is_vice_captain = $false
-            multiplier      = 2
-        },
-        [PSCustomObject]@{
-            element         = 115
-            position        = 12
-            is_captain      = $false
-            is_vice_captain = $false
-            multiplier      = 1
-        }
+                $Object = [PSCustomObject]@{
+                    element         = 122
+                    position        = 1
+                    is_captain      = $true
+                    is_vice_captain = $false
+                    multiplier      = 2
+                    selling_price   = 111
+                },
+                [PSCustomObject]@{
+                    element         = 115
+                    position        = 12
+                    is_captain      = $false
+                    is_vice_captain = $false
+                    multiplier      = 1
+                    selling_price   = 67
+                }
 
-        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplTeamPlayer'
-    }
-    It 'outputs an FPLTeamPlayer object' {
-        $Result[0].PSTypeNames | Should -Contain 'FplTeamPlayer'
-}
-It 'renames the Element property to PlayerId' {
-    $Result[0].Element | Should -BeNullOrEmpty
-$Result.PlayerId | Should -Be 122, 115
-}
-It 'sets the PlayingStatus property' {
-    $Result[0].PlayingStatus | Should -Be 'Starting'
-$Result[1].PlayingStatus | Should -Be 'Substitute'
-}
-It 'transfers properties from the FplPlayer object' {
-    $Result.Name | Should -Be 'Hazard', 'Alonso'
-$Result.Club | Should -Be 'Chelsea', 'Chelsea'
-$Result.Position | Should -Be 'Midfielder', 'Defender'
-}
-It 'calculates captain points for only the captain' {
-    $Result.Points | Should -Be 16, 2
-}
-}
-Context 'FplLineup' {
-    BeforeAll {
-        Mock Get-FplPlayer {
-            [PSCustomObject]@{
-                Name           = 'Hazard'
-                PlayerId       = 122
-                Club           = 'Chelsea'
-                Position       = 'Midfielder'
-                GameweekPoints = 8
-            },
-            [PSCustomObject]@{
-                Name           = 'Alonso'
-                PlayerId       = 115
-                Club           = 'Chelsea'
-                Position       = 'Defender'
-                GameweekPoints = 2
+                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplLineup'
+            }
+            It 'outputs an FPLLineup object' {
+                $Result[0].PSTypeNames | Should -Contain 'FplLineup'
+            }
+            It 'renames the Element property to PlayerId' {
+                $Result[0].Element | Should -BeNullOrEmpty
+                $Result.PlayerId | Should -Be 122, 115
+            }
+            It 'renames the Position property to PositionNumber' {
+                $Result[0].Element | Should -BeNullOrEmpty
+                $Result.PositionNumber | Should -Be 1, 12
+            }
+            It 'sets the PlayingStatus property' {
+                $Result[0].PlayingStatus | Should -Be 'Starting'
+                $Result[1].PlayingStatus | Should -Be 'Substitute'
+            }
+            It 'transfers properties from the FplPlayer object' {
+                $Result.Name | Should -Be 'Hazard', 'Alonso'
+                $Result.Club | Should -Be 'Chelsea', 'Chelsea'
+                $Result.Position | Should -Be 'Midfielder', 'Defender'
+            }
+            It 'calculates and sets selling price' {
+                $Result.SellingPrice | Should -Be 11.1, 6.7
             }
         }
-
-        $Object = [PSCustomObject]@{
-            element         = 122
-            position        = 1
-            is_captain      = $true
-            is_vice_captain = $false
-            multiplier      = 2
-            selling_price   = 111
-        },
-        [PSCustomObject]@{
-            element         = 115
-            position        = 12
-            is_captain      = $false
-            is_vice_captain = $false
-            multiplier      = 1
-            selling_price   = 67
-        }
-
-        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplLineup'
     }
-    It 'outputs an FPLLineup object' {
-        $Result[0].PSTypeNames | Should -Contain 'FplLineup'
-}
-It 'renames the Element property to PlayerId' {
-    $Result[0].Element | Should -BeNullOrEmpty
-$Result.PlayerId | Should -Be 122, 115
-}
-It 'renames the Position property to PositionNumber' {
-    $Result[0].Element | Should -BeNullOrEmpty
-$Result.PositionNumber | Should -Be 1, 12
-}
-It 'sets the PlayingStatus property' {
-    $Result[0].PlayingStatus | Should -Be 'Starting'
-$Result[1].PlayingStatus | Should -Be 'Substitute'
-}
-It 'transfers properties from the FplPlayer object' {
-    $Result.Name | Should -Be 'Hazard', 'Alonso'
-$Result.Club | Should -Be 'Chelsea', 'Chelsea'
-$Result.Position | Should -Be 'Midfielder', 'Defender'
-}
-It 'calculates and sets selling price' {
-    $Result.SellingPrice | Should -Be 11.1, 6.7
-}
-}
-}
 }

--- a/Tests/Private/ConvertTo-FplObject.Tests.ps1
+++ b/Tests/Private/ConvertTo-FplObject.Tests.ps1
@@ -28,421 +28,421 @@ InModuleScope 'PSFPL' {
             }
             It 'outputs an FplPlayer object' {
                 $Result.PSTypeNames | Should -Contain 'FplPlayer'
-            }
-            It 'converts diacritic characters' {
-                $Result.WebName | Should -Be 'Bellerin'
-            }
-            It 'converts property names to Pascal Case' {
-                $Result.psobject.properties.Name | Should -Be @('WebName', 'ElementType', 'Club', 'NowCost', 'PlayerId', 'Position', 'ClubId', 'Price')
-            }
-            It 'converts element type to position' {
-                $Result.Position | Should -Be 'Defender'
-            }
-            It 'converts team ID to club name' {
-                $Result.Club | Should -Be 'Arsenal'
-            }
-            It 'converts ID to Player ID' {
-                $Result.Id | Should -BeNullOrEmpty
-                $Result.PlayerId | Should -Be 4
-            }
         }
-        Context 'FplGameweek type' {
-            BeforeAll {
-                $Object = [PSCustomObject]@{
-                    id                  = 1
-                    deadline_time       = '08/10/2018 18:00:00'
-                    average_entry_score = 53
-                }
-                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplGameweek'
-            }
-            It 'outputs an FplGameweek object' {
-                $Result.PSTypeNames | Should -Contain 'FplGameweek'
-            }
-            It 'converts "Entry" in a property name to "Team"' {
-                $Result.psobject.properties.name | Should -Contain 'AverageTeamScore'
-            }
-            It 'converts DeadlineTime to a DateTime object' {
-                $Result.DeadlineTime | Should -BeOfType [DateTime]
-            }
-            It 'renames the Id property to Gameweek' {
-                $Result.Id | Should -BeNullOrEmpty
-                $Result.Gameweek | Should -BeExactly 1
-            }
-        }
-        Context 'FplFixture type' {
-            BeforeAll {
-                $Object = [PSCustomObject]@{
-                    event         = 1
-                    deadline_time = '2018-08-10T18:00:00Z'
-                    kickoff_time  = '2018-08-10T19:00:00Z'
-                    team_a        = 1
-                    team_h        = 2
-                    id            = 3
-                    stats         = @(
-                        [pscustomobject]@{
-                            goals_scored = [pscustomobject]@{
-                                a = @(
-                                    [pscustomobject]@{
-                                        value   = 1
-                                        element = 234
-                                    }
-                                )
-                                h = @(
-                                    [pscustomobject]@{
-                                        value   = 1
-                                        element = 286
-                                    },
-                                    [pscustomobject]@{
-                                        value   = 1
-                                        element = 302
-                                    }
-                                )
-                            }
-                        }
-                    )
-                },
-                [PSCustomObject]@{
-                    event         = 2
-                    deadline_time = $null
-                    kickoff_time  = $null
-                    gameweek      = $null
-                    team_a        = 3
-                    team_h        = 4
-                    id            = 5
-                    stats         = @(
-                        [pscustomobject]@{
-                            goals_scored = [pscustomobject]@{
-                                a = @(
-                                    [pscustomobject]@{
-                                        value   = 1
-                                        element = 234
-                                    }
-                                )
-                                h = @(
-                                    [pscustomobject]@{
-                                        value   = 1
-                                        element = 286
-                                    },
-                                    [pscustomobject]@{
-                                        value   = 1
-                                        element = 302
-                                    }
-                                )
-                            }
-                        }
-                    )
-                }
-
-                Mock Get-FplClubId {
-                    @{
-                        1 = 'Leicester'
-                        2 = 'Man Utd'
-                    }
-                }
-
-                Mock Get-FplElementId {
-                    @{
-                        234 = 'Vardy'
-                        286 = 'Shaw'
-                        302 = 'Pogba'
-                    }
-                }
-
-                $Result = ConvertTo-FplObject -InputObject $Object[0] -Type 'FplFixture'
-            }
-            It 'changes "Event" to "Gameweek" in property names' {
-                $Result.psobject.properties.Name | Should -Contain 'Gameweek'
-                $Result.psobject.properties.Name | Should -Not -Contain 'Event'
-            }
-            It 'converts DeadlineTime to a DateTime object' {
-                $Result.DeadlineTime | Should -BeOfType [DateTime]
-            }
-            It 'converts KickoffTime to a DateTime object' {
-                $Result.KickoffTime | Should -BeOfType [DateTime]
-            }
-            It 'converts team ID to name' {
-                $Result.Stats[0].ClubName | Should -Be 'Leicester'
-                $Result.Stats[1].ClubName | Should -Be 'Man Utd'
-            }
-            It 'flattens the nested stats property' {
-                $Result.Stats[0].psobject.Properties.Name | Should -Be  @(
-                    'PlayerId',
-                    'PlayerName',
-                    'StatType',
-                    'StatValue',
-                    'ClubName'
-                )
-            }
-            It 'converts stats player ID to name' {
-                $Result.Stats.PlayerName | Should -Be @(
-                    'Vardy',
-                    'Shaw',
-                    'Pogba'
-                )
-            }
-            It 'removes underscores from stat types' {
-                $Result.Stats.StatType | Should -Not -Match '_'
-            }
-            It 'converts stats club ID to name' {
-                $Result.Stats.ClubName | Should -Be @(
-                    'Leicester',
-                    'Man Utd',
-                    'Man Utd'
-                )
-            }
-            It 'converts ID to Fixture ID' {
-                $Result.Id | Should -BeNullOrEmpty
-                $Result.FixtureId | Should -Be 3
-            }
-            It 'handles null values for deadline, kickoff and gameweek' {
-                $Result = ConvertTo-FplObject -InputObject $Object[1] -Type 'FplFixture'
-                $Result.Gameweek, $Result.DeadlineTime, $Result.KickoffTime | Foreach-Object {
-                    $_ | Should -Be 'tbc'
-                }
-            }
-        }
-        Context 'FplLeagueTable type' {
-            BeforeAll {
-                $Object = @(
-                    [PSCustomObject]@{
-                        league    = [PSCustomObject]@{
-                            name = 'MyCustomLeague'
-                        }
-                        standings = [PSCustomObject]@{
-                            has_next = $false
-                            results  = [PSCustomObject]@{
-                                league = 12345
-                                entry  = 54321
-                            }
-                        }
-                    },
-                    [PSCustomObject]@{
-                        league    = [PSCustomObject]@{
-                            name = 'MyCustomLeague'
-                        }
-                        standings = [PSCustomObject]@{
-                            has_next = $false
-                            results  = [PSCustomObject]@{
-                                league = 12345
-                                entry  = 65432
-                            }
-                        }
-                    }
-                )
-
-                $Results = ConvertTo-FplObject -InputObject $Object -Type 'FplLeagueTable'
-            }
-            It 'adds the LeagueName property' {
-                $Results | Foreach-Object {$_.LeagueName | Should -Be 'MyCustomLeague'}
-            }
-            It 'renames the League property to LeagueId' {
-                $Results | Foreach-Object {$_.League | Should -BeNullOrEmpty}
-                $Results.LeagueId | Should -Contain 12345
-            }
-            It 'renames the Team property to TeamId' {
-                $Results | Foreach-Object {$_.Team | Should -BeNullOrEmpty}
-                $Results.TeamId | Should -Be 54321, 65432
-            }
-        }
-        Context 'FplTeam type' {
-            BeforeAll {
-                Mock Get-FplClubId {
-                    @{
-                        6 = 'Chelsea'
-                    }
-                }
-                $Object = [PSCustomObject]@{
-                    bank          = 13
-                    value         = 1013
-                    favouriteteam = 6
-                    id            = 123456
-                    player        = 987654321
-                }
-                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplTeam'
-            }
-            It 'divides the bank property by 10' {
-                $Result.Bank | Should -Be 1.3
-            }
-            It 'divides the value property by 10' {
-                $Result.Value | Should -Be 101.3
-            }
-            It 'replaces favourite team ID with name' {
-                $Result.FavouriteClub | Should -Be 'Chelsea'
-            }
-            It 'renames the Id property to TeamId' {
-                $Result.Id | Should -BeNullOrEmpty
-                $Result.TeamId | Should -Be 123456
-            }
-            It 'renames the Player property to PlayerId' {
-                $Result.Player | Should -BeNullOrEmpty
-                $Result.PlayerId | Should -Be 987654321
-            }
-        }
-        Context 'FplLeague' {
-            BeforeAll {
-                $Object = [PSCustomObject]@{
-                    classic = [PSCustomObject]@{
-                        Name        = 'Classic League'
-                        league_type = 'c'
-                        _scoring    = 'c'
-                        id          = 1
-                    }
-                    h2h     = @(
-                        [PSCustomObject]@{
-                            Name = 'cup'
-                            id   = 2
-                        },
-                        [PSCustomObject]@{
-                            Name        = 'H2H League'
-                            league_type = 's'
-                            _scoring    = 'h'
-                            id          = 3
-                        },
-                        [PSCustomObject]@{
-                            Name        = 'Classic League 2'
-                            league_type = 'x'
-                            _scoring    = 'c'
-                            id          = 4
-                        }
-                    )
-                }
-
-                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplLeague'
-            }
-            It 'outputs an FPLLeague object' {
-                $Result[0].PSTypeNames | Should -Contain 'FplLeague'
-            }
-            It 'adds the classic and h2h leagues together leaving out the cup' {
-                $Result.Name | Should -Be 'Classic League', 'H2H League', 'Classic League 2'
-            }
-            It 'converts the LeagueType parameter' {
-                $Result.LeagueType | Should -Be 'Public', 'Global', 'Private'
-            }
-            It 'converts the Scoring parameter' {
-                $Result.Scoring | Should -Be 'Classic', 'H2H', 'Classic'
-            }
-            It 'converts ID to League ID' {
-                $Result.foreach{$_.Id | Should -BeNullOrEmpty}
-                $Result.LeagueId | Should -Be 1, 3, 4
-            }
-        }
-        Context 'FplTeamPlayer' {
-            BeforeAll {
-                Mock Get-FplPlayer {
-                    [PSCustomObject]@{
-                        WebName        = 'Hazard'
-                        PlayerId       = 122
-                        Club           = 'Chelsea'
-                        Position       = 'Midfielder'
-                        GameweekPoints = 8
-                    },
-                    [PSCustomObject]@{
-                        WebName        = 'Alonso'
-                        PlayerId       = 115
-                        Club           = 'Chelsea'
-                        Position       = 'Defender'
-                        GameweekPoints = 2
-                    }
-                }
-
-                $Object = [PSCustomObject]@{
-                    element         = 122
-                    position        = 1
-                    is_captain      = $true
-                    is_vice_captain = $false
-                    multiplier      = 2
-                },
-                [PSCustomObject]@{
-                    element         = 115
-                    position        = 12
-                    is_captain      = $false
-                    is_vice_captain = $false
-                    multiplier      = 1
-                }
-
-                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplTeamPlayer'
-            }
-            It 'outputs an FPLTeamPlayer object' {
-                $Result[0].PSTypeNames | Should -Contain 'FplTeamPlayer'
-            }
-            It 'renames the Element property to PlayerId' {
-                $Result[0].Element | Should -BeNullOrEmpty
-                $Result.PlayerId | Should -Be 122, 115
-            }
-            It 'sets the PlayingStatus property' {
-                $Result[0].PlayingStatus | Should -Be 'Starting'
-                $Result[1].PlayingStatus | Should -Be 'Substitute'
-            }
-            It 'transfers properties from the FplPlayer object' {
-                $Result.WebName | Should -Be 'Hazard', 'Alonso'
-                $Result.Club | Should -Be 'Chelsea', 'Chelsea'
-                $Result.Position | Should -Be 'Midfielder', 'Defender'
-            }
-            It 'calculates captain points for only the captain' {
-                $Result.Points | Should -Be 16, 2
-            }
-        }
-        Context 'FplLineup' {
-            BeforeAll {
-                Mock Get-FplPlayer {
-                    [PSCustomObject]@{
-                        WebName        = 'Hazard'
-                        PlayerId       = 122
-                        Club           = 'Chelsea'
-                        Position       = 'Midfielder'
-                        GameweekPoints = 8
-                    },
-                    [PSCustomObject]@{
-                        WebName        = 'Alonso'
-                        PlayerId       = 115
-                        Club           = 'Chelsea'
-                        Position       = 'Defender'
-                        GameweekPoints = 2
-                    }
-                }
-
-                $Object = [PSCustomObject]@{
-                    element         = 122
-                    position        = 1
-                    is_captain      = $true
-                    is_vice_captain = $false
-                    multiplier      = 2
-                    selling_price   = 111
-                },
-                [PSCustomObject]@{
-                    element         = 115
-                    position        = 12
-                    is_captain      = $false
-                    is_vice_captain = $false
-                    multiplier      = 1
-                    selling_price   = 67
-                }
-
-                $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplLineup'
-            }
-            It 'outputs an FPLLineup object' {
-                $Result[0].PSTypeNames | Should -Contain 'FplLineup'
-            }
-            It 'renames the Element property to PlayerId' {
-                $Result[0].Element | Should -BeNullOrEmpty
-                $Result.PlayerId | Should -Be 122, 115
-            }
-            It 'renames the Position property to PositionNumber' {
-                $Result[0].Element | Should -BeNullOrEmpty
-                $Result.PositionNumber | Should -Be 1, 12
-            }
-            It 'sets the PlayingStatus property' {
-                $Result[0].PlayingStatus | Should -Be 'Starting'
-                $Result[1].PlayingStatus | Should -Be 'Substitute'
-            }
-            It 'transfers properties from the FplPlayer object' {
-                $Result.WebName | Should -Be 'Hazard', 'Alonso'
-                $Result.Club | Should -Be 'Chelsea', 'Chelsea'
-                $Result.Position | Should -Be 'Midfielder', 'Defender'
-            }
-            It 'calculates and sets selling price' {
-                $Result.SellingPrice | Should -Be 11.1, 6.7
-            }
-        }
+        It 'converts diacritic characters' {
+            $Result.Name | Should -Be 'Bellerin'
     }
+    It 'converts property names to Pascal Case' {
+        $Result.psobject.properties.Name | Should -Be @('WebName', 'ElementType', 'Club', 'NowCost', 'PlayerId', 'Name', 'Position', 'ClubId', 'Price')
+}
+It 'converts element type to position' {
+    $Result.Position | Should -Be 'Defender'
+}
+It 'converts team ID to club name' {
+    $Result.Club | Should -Be 'Arsenal'
+}
+It 'converts ID to Player ID' {
+    $Result.Id | Should -BeNullOrEmpty
+$Result.PlayerId | Should -Be 4
+}
+}
+Context 'FplGameweek type' {
+    BeforeAll {
+        $Object = [PSCustomObject]@{
+            id                  = 1
+            deadline_time       = '08/10/2018 18:00:00'
+            average_entry_score = 53
+        }
+        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplGameweek'
+    }
+    It 'outputs an FplGameweek object' {
+        $Result.PSTypeNames | Should -Contain 'FplGameweek'
+}
+It 'converts "Entry" in a property name to "Team"' {
+    $Result.psobject.properties.name | Should -Contain 'AverageTeamScore'
+}
+It 'converts DeadlineTime to a DateTime object' {
+    $Result.DeadlineTime | Should -BeOfType [DateTime]
+}
+It 'renames the Id property to Gameweek' {
+    $Result.Id | Should -BeNullOrEmpty
+$Result.Gameweek | Should -BeExactly 1
+}
+}
+Context 'FplFixture type' {
+    BeforeAll {
+        $Object = [PSCustomObject]@{
+            event         = 1
+            deadline_time = '2018-08-10T18:00:00Z'
+            kickoff_time  = '2018-08-10T19:00:00Z'
+            team_a        = 1
+            team_h        = 2
+            id            = 3
+            stats         = @(
+                [pscustomobject]@{
+                    goals_scored = [pscustomobject]@{
+                        a = @(
+                            [pscustomobject]@{
+                                value   = 1
+                                element = 234
+                            }
+                        )
+                        h = @(
+                            [pscustomobject]@{
+                                value   = 1
+                                element = 286
+                            },
+                            [pscustomobject]@{
+                                value   = 1
+                                element = 302
+                            }
+                        )
+                    }
+                }
+            )
+        },
+        [PSCustomObject]@{
+            event         = 2
+            deadline_time = $null
+            kickoff_time  = $null
+            gameweek      = $null
+            team_a        = 3
+            team_h        = 4
+            id            = 5
+            stats         = @(
+                [pscustomobject]@{
+                    goals_scored = [pscustomobject]@{
+                        a = @(
+                            [pscustomobject]@{
+                                value   = 1
+                                element = 234
+                            }
+                        )
+                        h = @(
+                            [pscustomobject]@{
+                                value   = 1
+                                element = 286
+                            },
+                            [pscustomobject]@{
+                                value   = 1
+                                element = 302
+                            }
+                        )
+                    }
+                }
+            )
+        }
+
+        Mock Get-FplClubId {
+            @{
+                1 = 'Leicester'
+                2 = 'Man Utd'
+            }
+        }
+
+        Mock Get-FplElementId {
+            @{
+                234 = 'Vardy'
+                286 = 'Shaw'
+                302 = 'Pogba'
+            }
+        }
+
+        $Result = ConvertTo-FplObject -InputObject $Object[0] -Type 'FplFixture'
+    }
+    It 'changes "Event" to "Gameweek" in property names' {
+        $Result.psobject.properties.Name | Should -Contain 'Gameweek'
+    $Result.psobject.properties.Name | Should -Not -Contain 'Event'
+}
+It 'converts DeadlineTime to a DateTime object' {
+    $Result.DeadlineTime | Should -BeOfType [DateTime]
+}
+It 'converts KickoffTime to a DateTime object' {
+    $Result.KickoffTime | Should -BeOfType [DateTime]
+}
+It 'converts team ID to name' {
+    $Result.Stats[0].ClubName | Should -Be 'Leicester'
+$Result.Stats[1].ClubName | Should -Be 'Man Utd'
+}
+It 'flattens the nested stats property' {
+    $Result.Stats[0].psobject.Properties.Name | Should -Be  @(
+        'PlayerId',
+        'PlayerName',
+        'StatType',
+        'StatValue',
+        'ClubName'
+    )
+}
+It 'converts stats player ID to name' {
+    $Result.Stats.PlayerName | Should -Be @(
+        'Vardy',
+        'Shaw',
+        'Pogba'
+    )
+}
+It 'removes underscores from stat types' {
+    $Result.Stats.StatType | Should -Not -Match '_'
+}
+It 'converts stats club ID to name' {
+    $Result.Stats.ClubName | Should -Be @(
+        'Leicester',
+        'Man Utd',
+        'Man Utd'
+    )
+}
+It 'converts ID to Fixture ID' {
+    $Result.Id | Should -BeNullOrEmpty
+$Result.FixtureId | Should -Be 3
+}
+It 'handles null values for deadline, kickoff and gameweek' {
+    $Result = ConvertTo-FplObject -InputObject $Object[1] -Type 'FplFixture'
+    $Result.Gameweek, $Result.DeadlineTime, $Result.KickoffTime | ForEach-Object {
+        $_ | Should -Be 'tbc'
+}
+}
+}
+Context 'FplLeagueTable type' {
+    BeforeAll {
+        $Object = @(
+            [PSCustomObject]@{
+                league    = [PSCustomObject]@{
+                    name = 'MyCustomLeague'
+                }
+                standings = [PSCustomObject]@{
+                    has_next = $false
+                    results  = [PSCustomObject]@{
+                        league = 12345
+                        entry  = 54321
+                    }
+                }
+            },
+            [PSCustomObject]@{
+                league    = [PSCustomObject]@{
+                    name = 'MyCustomLeague'
+                }
+                standings = [PSCustomObject]@{
+                    has_next = $false
+                    results  = [PSCustomObject]@{
+                        league = 12345
+                        entry  = 65432
+                    }
+                }
+            }
+        )
+
+        $Results = ConvertTo-FplObject -InputObject $Object -Type 'FplLeagueTable'
+    }
+    It 'adds the LeagueName property' {
+        $Results | ForEach-Object {$_.LeagueName | Should -Be 'MyCustomLeague'}
+}
+It 'renames the League property to LeagueId' {
+    $Results | ForEach-Object {$_.League | Should -BeNullOrEmpty}
+$Results.LeagueId | Should -Contain 12345
+}
+It 'renames the Team property to TeamId' {
+    $Results | ForEach-Object {$_.Team | Should -BeNullOrEmpty}
+$Results.TeamId | Should -Be 54321, 65432
+}
+}
+Context 'FplTeam type' {
+    BeforeAll {
+        Mock Get-FplClubId {
+            @{
+                6 = 'Chelsea'
+            }
+        }
+        $Object = [PSCustomObject]@{
+            bank          = 13
+            value         = 1013
+            favouriteteam = 6
+            id            = 123456
+            player        = 987654321
+        }
+        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplTeam'
+    }
+    It 'divides the bank property by 10' {
+        $Result.Bank | Should -Be 1.3
+}
+It 'divides the value property by 10' {
+    $Result.Value | Should -Be 101.3
+}
+It 'replaces favourite team ID with name' {
+    $Result.FavouriteClub | Should -Be 'Chelsea'
+}
+It 'renames the Id property to TeamId' {
+    $Result.Id | Should -BeNullOrEmpty
+$Result.TeamId | Should -Be 123456
+}
+It 'renames the Player property to PlayerId' {
+    $Result.Player | Should -BeNullOrEmpty
+$Result.PlayerId | Should -Be 987654321
+}
+}
+Context 'FplLeague' {
+    BeforeAll {
+        $Object = [PSCustomObject]@{
+            classic = [PSCustomObject]@{
+                Name        = 'Classic League'
+                league_type = 'c'
+                _scoring    = 'c'
+                id          = 1
+            }
+            h2h     = @(
+                [PSCustomObject]@{
+                    Name = 'cup'
+                    id   = 2
+                },
+                [PSCustomObject]@{
+                    Name        = 'H2H League'
+                    league_type = 's'
+                    _scoring    = 'h'
+                    id          = 3
+                },
+                [PSCustomObject]@{
+                    Name        = 'Classic League 2'
+                    league_type = 'x'
+                    _scoring    = 'c'
+                    id          = 4
+                }
+            )
+        }
+
+        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplLeague'
+    }
+    It 'outputs an FPLLeague object' {
+        $Result[0].PSTypeNames | Should -Contain 'FplLeague'
+}
+It 'adds the classic and h2h leagues together leaving out the cup' {
+    $Result.Name | Should -Be 'Classic League', 'H2H League', 'Classic League 2'
+}
+It 'converts the LeagueType parameter' {
+    $Result.LeagueType | Should -Be 'Public', 'Global', 'Private'
+}
+It 'converts the Scoring parameter' {
+    $Result.Scoring | Should -Be 'Classic', 'H2H', 'Classic'
+}
+It 'converts ID to League ID' {
+    $Result.foreach{$_.Id | Should -BeNullOrEmpty}
+$Result.LeagueId | Should -Be 1, 3, 4
+}
+}
+Context 'FplTeamPlayer' {
+    BeforeAll {
+        Mock Get-FplPlayer {
+            [PSCustomObject]@{
+                Name           = 'Hazard'
+                PlayerId       = 122
+                Club           = 'Chelsea'
+                Position       = 'Midfielder'
+                GameweekPoints = 8
+            },
+            [PSCustomObject]@{
+                Name           = 'Alonso'
+                PlayerId       = 115
+                Club           = 'Chelsea'
+                Position       = 'Defender'
+                GameweekPoints = 2
+            }
+        }
+
+        $Object = [PSCustomObject]@{
+            element         = 122
+            position        = 1
+            is_captain      = $true
+            is_vice_captain = $false
+            multiplier      = 2
+        },
+        [PSCustomObject]@{
+            element         = 115
+            position        = 12
+            is_captain      = $false
+            is_vice_captain = $false
+            multiplier      = 1
+        }
+
+        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplTeamPlayer'
+    }
+    It 'outputs an FPLTeamPlayer object' {
+        $Result[0].PSTypeNames | Should -Contain 'FplTeamPlayer'
+}
+It 'renames the Element property to PlayerId' {
+    $Result[0].Element | Should -BeNullOrEmpty
+$Result.PlayerId | Should -Be 122, 115
+}
+It 'sets the PlayingStatus property' {
+    $Result[0].PlayingStatus | Should -Be 'Starting'
+$Result[1].PlayingStatus | Should -Be 'Substitute'
+}
+It 'transfers properties from the FplPlayer object' {
+    $Result.Name | Should -Be 'Hazard', 'Alonso'
+$Result.Club | Should -Be 'Chelsea', 'Chelsea'
+$Result.Position | Should -Be 'Midfielder', 'Defender'
+}
+It 'calculates captain points for only the captain' {
+    $Result.Points | Should -Be 16, 2
+}
+}
+Context 'FplLineup' {
+    BeforeAll {
+        Mock Get-FplPlayer {
+            [PSCustomObject]@{
+                Name           = 'Hazard'
+                PlayerId       = 122
+                Club           = 'Chelsea'
+                Position       = 'Midfielder'
+                GameweekPoints = 8
+            },
+            [PSCustomObject]@{
+                Name           = 'Alonso'
+                PlayerId       = 115
+                Club           = 'Chelsea'
+                Position       = 'Defender'
+                GameweekPoints = 2
+            }
+        }
+
+        $Object = [PSCustomObject]@{
+            element         = 122
+            position        = 1
+            is_captain      = $true
+            is_vice_captain = $false
+            multiplier      = 2
+            selling_price   = 111
+        },
+        [PSCustomObject]@{
+            element         = 115
+            position        = 12
+            is_captain      = $false
+            is_vice_captain = $false
+            multiplier      = 1
+            selling_price   = 67
+        }
+
+        $Result = ConvertTo-FplObject -InputObject $Object -Type 'FplLineup'
+    }
+    It 'outputs an FPLLineup object' {
+        $Result[0].PSTypeNames | Should -Contain 'FplLineup'
+}
+It 'renames the Element property to PlayerId' {
+    $Result[0].Element | Should -BeNullOrEmpty
+$Result.PlayerId | Should -Be 122, 115
+}
+It 'renames the Position property to PositionNumber' {
+    $Result[0].Element | Should -BeNullOrEmpty
+$Result.PositionNumber | Should -Be 1, 12
+}
+It 'sets the PlayingStatus property' {
+    $Result[0].PlayingStatus | Should -Be 'Starting'
+$Result[1].PlayingStatus | Should -Be 'Substitute'
+}
+It 'transfers properties from the FplPlayer object' {
+    $Result.Name | Should -Be 'Hazard', 'Alonso'
+$Result.Club | Should -Be 'Chelsea', 'Chelsea'
+$Result.Position | Should -Be 'Midfielder', 'Defender'
+}
+It 'calculates and sets selling price' {
+    $Result.SellingPrice | Should -Be 11.1, 6.7
+}
+}
+}
 }

--- a/Tests/Private/Invoke-FplLineupSwap.Tests.ps1
+++ b/Tests/Private/Invoke-FplLineupSwap.Tests.ps1
@@ -6,105 +6,105 @@ InModuleScope 'PSFPL' {
                 [PSCustomObject]@{
                     PositionNumber = 1
                     PlayerId       = 400
-                    WebName        = 'Fabianski'
+                    Name        = 'Fabianski'
                     Position       = 'GoalKeeper'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 2
                     PlayerId       = 335
-                    WebName        = 'Bednarek'
+                    Name        = 'Bednarek'
                     Position       = 'Defender'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 3
                     PlayerId       = 427
-                    WebName        = 'Bennett'
+                    Name        = 'Bennett'
                     Position       = 'Defender'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 4
                     PlayerId       = 245
-                    WebName        = 'Alexander-Arnold'
+                    Name        = 'Alexander-Arnold'
                     Position       = 'Defender'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 5
                     PlayerId       = 302
-                    WebName        = 'Pogba'
+                    Name        = 'Pogba'
                     Position       = 'Midfielder'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 6
                     PlayerId       = 275
-                    WebName        = 'Sane'
+                    Name        = 'Sane'
                     Position       = 'Midfielder'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 7
                     PlayerId       = 253
-                    WebName        = 'Salah'
+                    Name        = 'Salah'
                     Position       = 'Midfielder'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 8
                     PlayerId       = 270
-                    WebName        = 'Sterling'
+                    Name        = 'Sterling'
                     Position       = 'Midfielder'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 9
                     PlayerId       = 367
-                    WebName        = 'Son'
+                    Name        = 'Son'
                     Position       = 'Midfielder'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 10
                     PlayerId       = 305
-                    WebName        = 'Rashford'
+                    Name        = 'Rashford'
                     Position       = 'Forward'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 11
                     PlayerId       = 437
-                    WebName        = 'Jimenez'
+                    Name        = 'Jimenez'
                     Position       = 'Forward'
                     IsSub          = $false
                 },
                 [PSCustomObject]@{
                     PositionNumber = 12
                     PlayerId       = 190
-                    WebName        = 'Hamer'
+                    Name        = 'Hamer'
                     Position       = 'Goalkeeper'
                     IsSub          = $true
                 },
                 [PSCustomObject]@{
                     PositionNumber = 13
                     PlayerId       = 258
-                    WebName        = 'Ings'
+                    Name        = 'Ings'
                     Position       = 'Forward'
                     IsSub          = $true
                 },
                 [PSCustomObject]@{
                     PositionNumber = 14
                     PlayerId       = 484
-                    WebName        = 'Digne'
+                    Name        = 'Digne'
                     Position       = 'Defender'
                     IsSub          = $true
                 },
                 [PSCustomObject]@{
                     PositionNumber = 15
                     PlayerId       = 409
-                    WebName        = 'Diop'
+                    Name        = 'Diop'
                     Position       = 'Defender'
                     IsSub          = $true
                 }
@@ -117,37 +117,37 @@ InModuleScope 'PSFPL' {
             $Params['PlayersIn'] = 'Ings'
             $Params['PlayersOut'] = 'Rashford'
             $Result = Invoke-FplLineupSwap @Params
-            $Result[9].WebName | Should -Be 'Ings'
-            $Result[12].WebName | Should -Be 'Rashford'
+            $Result[9].Name | Should -Be 'Ings'
+            $Result[12].Name | Should -Be 'Rashford'
         }
         It 'swaps multiple players of the same positions' {
             $Params['PlayersIn'] = 'Ings', 'Diop', 'Digne'
             $Params['PlayersOut'] = 'Rashford', 'Bednarek', 'Bennett'
             $Result = Invoke-FplLineupSwap @Params
-            $Result[9].WebName | Should -Be 'Ings'
-            $Result[12].WebName | Should -Be 'Rashford'
-            $Result[1].WebName | Should -Be 'Diop'
-            $Result[14].WebName | Should -Be 'Bednarek'
-            $Result[2].WebName | Should -Be 'Digne'
-            $Result[13].WebName | Should -Be 'Bennett'
+            $Result[9].Name | Should -Be 'Ings'
+            $Result[12].Name | Should -Be 'Rashford'
+            $Result[1].Name | Should -Be 'Diop'
+            $Result[14].Name | Should -Be 'Bednarek'
+            $Result[2].Name | Should -Be 'Digne'
+            $Result[13].Name | Should -Be 'Bennett'
         }
         It 'swaps a single player of a different type' {
             $Params['PlayersIn'] = 'Ings'
             $Params['PlayersOut'] = 'Bennett'
             $Result = Invoke-FplLineupSwap @Params
-            $Result[8].WebName | Should -Be 'Ings'
-            $Result[12].WebName | Should -Be 'Bennett'
+            $Result[8].Name | Should -Be 'Ings'
+            $Result[12].Name | Should -Be 'Bennett'
         }
         It 'swaps multiple players of different types' {
             $Params['PlayersIn'] = 'Ings', 'Diop', 'Digne'
             $Params['PlayersOut'] = 'Son', 'Rashford', 'Sane'
             $Result = Invoke-FplLineupSwap @Params
-            $Result[9].WebName | Should -Be 'Ings'
-            $Result[12].WebName | Should -Be 'Son'
-            $Result[4].WebName | Should -Be 'Diop'
-            $Result[14].WebName | Should -Be 'Rashford'
-            $Result[5].WebName | Should -Be 'Digne'
-            $Result[13].WebName | Should -Be 'Sane'
+            $Result[9].Name | Should -Be 'Ings'
+            $Result[12].Name | Should -Be 'Son'
+            $Result[4].Name | Should -Be 'Diop'
+            $Result[14].Name | Should -Be 'Rashford'
+            $Result[5].Name | Should -Be 'Digne'
+            $Result[13].Name | Should -Be 'Sane'
         }
         It 'sorts the new starting XI' {
             $Params['PlayersIn'] = 'Ings', 'Diop', 'Digne'

--- a/Tests/Private/Set-FplLineupCaptain.Tests.ps1
+++ b/Tests/Private/Set-FplLineupCaptain.Tests.ps1
@@ -6,7 +6,7 @@ InModuleScope 'PSFPL' {
                 [PSCustomObject]@{
                     PositionNumber = 1
                     PlayerId       = 400
-                    WebName        = 'Fabianski'
+                    Name        = 'Fabianski'
                     Position       = 'GoalKeeper'
                     IsCaptain      = $true
                     IsViceCaptain  = $false
@@ -14,7 +14,7 @@ InModuleScope 'PSFPL' {
                 [PSCustomObject]@{
                     PositionNumber = 2
                     PlayerId       = 335
-                    WebName        = 'Bednarek'
+                    Name        = 'Bednarek'
                     Position       = 'Defender'
                     IsCaptain      = $false
                     IsViceCaptain  = $true
@@ -22,7 +22,7 @@ InModuleScope 'PSFPL' {
                 [PSCustomObject]@{
                     PositionNumber = 3
                     PlayerId       = 427
-                    WebName        = 'Bennett'
+                    Name        = 'Bennett'
                     Position       = 'Defender'
                     IsCaptain      = $false
                     IsViceCaptain  = $false
@@ -30,7 +30,7 @@ InModuleScope 'PSFPL' {
                 [PSCustomObject]@{
                     PositionNumber = 15
                     PlayerId       = 409
-                    WebName        = 'Diop'
+                    Name        = 'Diop'
                     Position       = 'Defender'
                     IsCaptain      = $false
                     IsViceCaptain  = $false
@@ -46,19 +46,19 @@ InModuleScope 'PSFPL' {
         It 'sets a new captain' {
             $Params['Captain'] = 'Bennett'
             $Result = Set-FplLineupCaptain @Params
-            $Result.Where{$_.IsCaptain}.WebName | Should -Be 'Bennett'
+            $Result.Where{$_.IsCaptain}.Name | Should -Be 'Bennett'
         }
         It 'sets a new vice captain' {
             $Params['ViceCaptain'] = 'Bennett'
             $Result = Set-FplLineupCaptain @Params
-            $Result.Where{$_.IsViceCaptain}.WebName | Should -Be 'Bennett'
+            $Result.Where{$_.IsViceCaptain}.Name | Should -Be 'Bennett'
         }
         It 'sets a new captain and a new vice captain' {
             $Params['Captain'] = 'Bennett'
             $Params['ViceCaptain'] = 'Fabianski'
             $Result = Set-FplLineupCaptain @Params
-            $Result.Where{$_.IsCaptain}.WebName | Should -Be 'Bennett'
-            $Result.Where{$_.IsViceCaptain}.WebName | Should -Be 'Fabianski'
+            $Result.Where{$_.IsCaptain}.Name | Should -Be 'Bennett'
+            $Result.Where{$_.IsViceCaptain}.Name | Should -Be 'Fabianski'
         }
         It 'errors if a substitute is set as the new captain' {
             $Params['Captain'] = 'Diop'

--- a/Tests/Public/Get-FplGameweek.Tests.ps1
+++ b/Tests/Public/Get-FplGameweek.Tests.ps1
@@ -6,12 +6,12 @@ InModuleScope 'PSFPL' {
             Mock ConvertTo-FplObject {
                 @(
                     [pscustomobject]@{
-                        Id        = 1
+                        Gameweek  = 1
                         Name      = 'Gameweek 1'
                         IsCurrent = $false
                     },
                     [pscustomobject]@{
-                        Id        = 2
+                        Gameweek  = 2
                         Name      = 'Gameweek 2'
                         IsCurrent = $true
                     }

--- a/Tests/Public/Get-FplPlayer.Tests.ps1
+++ b/Tests/Public/Get-FplPlayer.Tests.ps1
@@ -6,7 +6,7 @@ InModuleScope 'PSFPL' {
             Mock ConvertTo-FplObject {
                 @(
                     [pscustomobject]@{
-                        WebName     = 'Ederson'
+                        Name     = 'Ederson'
                         Position    = 'Goalkeeper'
                         Club        = 'Man City'
                         Price       = 5.8
@@ -14,7 +14,7 @@ InModuleScope 'PSFPL' {
                         TotalPoints = 62
                     },
                     [pscustomobject]@{
-                        WebName     = 'Alonso'
+                        Name     = 'Alonso'
                         Position    = 'Defender'
                         Club        = 'Chelsea'
                         Price       = 7.1
@@ -22,7 +22,7 @@ InModuleScope 'PSFPL' {
                         TotalPoints = 86
                     },
                     [pscustomobject]@{
-                        WebName     = 'Richarlison'
+                        Name     = 'Richarlison'
                         Position    = 'Midfielder'
                         Club        = 'Everton'
                         Price       = 7.0
@@ -30,7 +30,7 @@ InModuleScope 'PSFPL' {
                         TotalPoints = 59
                     },
                     [pscustomobject]@{
-                        WebName     = 'Arnautovic'
+                        Name     = 'Arnautovic'
                         Position    = 'Forward'
                         Club        = 'West Ham'
                         Price       = 7.1
@@ -47,30 +47,30 @@ InModuleScope 'PSFPL' {
             }
             It 'Filters correctly on the Name parameter' {
                 $Result = Get-FplPlayer -Name 'Ederson'
-                $Result.WebName | Should -Be 'Ederson'
+                $Result.Name | Should -Be 'Ederson'
 
                 $Result = Get-FplPlayer -Name 'ar'
-                $Result.WebName | Should -Contain 'Arnautovic'
-                $Result.WebName | Should -Contain 'Richarlison'
-                $Result.WebName | Should -Not -Contain 'Ederson'
+                $Result.Name | Should -Contain 'Arnautovic'
+                $Result.Name | Should -Contain 'Richarlison'
+                $Result.Name | Should -Not -Contain 'Ederson'
             }
             It 'accepts pipeline input on the Name parameter' {
                 $Result = 'Ederson' | Get-FplPlayer
-                $Result.WebName | Should -Be 'Ederson'
+                $Result.Name | Should -Be 'Ederson'
             }
             It 'Filters correctly on the Position parameter' {
                 $Result = Get-FplPlayer -Position 'Defender'
-                $Result.WebName | Should -Be 'Alonso'
+                $Result.Name | Should -Be 'Alonso'
             }
             It 'Filters correctly on the Club parameter' {
                 $Result = Get-FplPlayer -Club 'Chelsea'
-                $Result.WebName | Should -Be 'Alonso'
+                $Result.Name | Should -Be 'Alonso'
             }
             It 'Filters correctly on the MaxPrice parameter' {
                 $Result = Get-FplPlayer -MaxPrice 7
                 $Result.count | Should -Be 2
-                $Result.WebName | Should -Contain 'Ederson'
-                $Result.WebName | Should -Not -Contain 'Alonso'
+                $Result.Name | Should -Contain 'Ederson'
+                $Result.Name | Should -Not -Contain 'Alonso'
             }
             It 'Sorts by TotalPoints' {
                 $Result = Get-FplPlayer
@@ -92,8 +92,8 @@ InModuleScope 'PSFPL' {
                 $Result = Get-FplPlayer -DreamTeam
             }
             It 'Only lists players in the dream team' {
-                $Result.WebName | Should -Contain 'Alonso'
-                $Result.WebName | Should -Not -Contain 'Arnautovic'
+                $Result.Name | Should -Contain 'Alonso'
+                $Result.Name | Should -Not -Contain 'Arnautovic'
             }
 
             It 'Outputs the dream team in the correct order' {

--- a/Tests/Public/Get-FplTeam.Tests.ps1
+++ b/Tests/Public/Get-FplTeam.Tests.ps1
@@ -12,11 +12,11 @@ InModuleScope 'PSFPL' {
             }
             It 'passes the TeamId onto Invoke-RestMethod' {
                 $Results = Get-FplTeam -TeamId 123456
-                Assert-MockCalled Invoke-RestMethod -ParameterFilter {$Uri -eq 'https://fantasy.premierleague.com/drf/entry/123456/'} -Scope 'It'
+                Assert-MockCalled Invoke-RestMethod -ParameterFilter {$Uri -eq 'https://fantasy.premierleague.com/drf/entry/123456'} -Scope 'It'
             }
             It 'accepts pipeline input' {
                 $Results = 123456 | Get-FplTeam
-                Assert-MockCalled Invoke-RestMethod -ParameterFilter {$Uri -eq 'https://fantasy.premierleague.com/drf/entry/123456/'} -Scope 'It'
+                Assert-MockCalled Invoke-RestMethod -ParameterFilter {$Uri -eq 'https://fantasy.premierleague.com/drf/entry/123456'} -Scope 'It'
             }
         }
         Context 'No TeamID whilst not logged in' {

--- a/Tests/Public/Set-FplLineup.Tests.ps1
+++ b/Tests/Public/Set-FplLineup.Tests.ps1
@@ -14,12 +14,12 @@ InModuleScope 'PSFPL' {
             }
             Mock Get-FplLineup {
                 [PSCustomObject]@{
-                    WebName       = 'Sterling'
+                    Name       = 'Sterling'
                     IsCaptain     = $false
                     IsViceCaptain = $false
                 },
                 [PSCustomObject]@{
-                    WebName       = 'Digne'
+                    Name       = 'Digne'
                     IsCaptain     = $false
                     IsViceCaptain = $false
                 }


### PR DESCRIPTION
This PR will change the WebName property for an FplPlayer object to Name.

WebName is the terminology used by the API which was adopted initially but I don't see the need to keep it this way and think Name would be a better name for the property.

In order to keep backwards compatibility WebName will still exist as a property.