### PR TITLE
Add wildcard support for the Name parameter in Get-FplPlayer

### DIFF
--- a/PSFPL/Public/Get-FplPlayer.ps1
+++ b/PSFPL/Public/Get-FplPlayer.ps1
@@ -43,10 +43,12 @@ function Get-FplPlayer {
     Param (
         [Parameter(
             ParameterSetName = 'Filter',
-            ValueFromPipeline
+            ValueFromPipeline,
+            Position = 0
         )]
+        [SupportsWildcards()]
         [string]
-        $Name,
+        $Name = '*',
 
         [Parameter(ParameterSetName = 'Filter')]
         [ValidateSet('Forward', 'Midfielder', 'Defender', 'Goalkeeper')]
@@ -79,6 +81,7 @@ function Get-FplPlayer {
         $Players = ConvertTo-FplObject -InputObject $Response -Type 'FplPlayer' | Sort-Object TotalPoints, Price -Descending
     }
     Process {
+        $Name = '^{0}$' -f ($Name -replace '\*', '.*')
         $Output = $Players.Where{
             $_.Name -match $Name -and
             $_.Position -match $Position -and

--- a/Tests/Public/Get-FplPlayer.Tests.ps1
+++ b/Tests/Public/Get-FplPlayer.Tests.ps1
@@ -6,7 +6,7 @@ InModuleScope 'PSFPL' {
             Mock ConvertTo-FplObject {
                 @(
                     [pscustomobject]@{
-                        Name     = 'Ederson'
+                        Name        = 'Ederson'
                         Position    = 'Goalkeeper'
                         Club        = 'Man City'
                         Price       = 5.8
@@ -14,7 +14,7 @@ InModuleScope 'PSFPL' {
                         TotalPoints = 62
                     },
                     [pscustomobject]@{
-                        Name     = 'Alonso'
+                        Name        = 'Alonso'
                         Position    = 'Defender'
                         Club        = 'Chelsea'
                         Price       = 7.1
@@ -22,7 +22,7 @@ InModuleScope 'PSFPL' {
                         TotalPoints = 86
                     },
                     [pscustomobject]@{
-                        Name     = 'Richarlison'
+                        Name        = 'Richarlison'
                         Position    = 'Midfielder'
                         Club        = 'Everton'
                         Price       = 7.0
@@ -30,7 +30,7 @@ InModuleScope 'PSFPL' {
                         TotalPoints = 59
                     },
                     [pscustomobject]@{
-                        Name     = 'Arnautovic'
+                        Name        = 'Arnautovic'
                         Position    = 'Forward'
                         Club        = 'West Ham'
                         Price       = 7.1
@@ -45,14 +45,17 @@ InModuleScope 'PSFPL' {
                 $Results = Get-FplPlayer
                 $Results.count | Should -Be 4
             }
-            It 'Filters correctly on the Name parameter' {
+            It 'filters correctly on the Name parameter' {
                 $Result = Get-FplPlayer -Name 'Ederson'
                 $Result.Name | Should -Be 'Ederson'
 
-                $Result = Get-FplPlayer -Name 'ar'
+                $Result = Get-FplPlayer -Name '*ar*'
                 $Result.Name | Should -Contain 'Arnautovic'
                 $Result.Name | Should -Contain 'Richarlison'
                 $Result.Name | Should -Not -Contain 'Ederson'
+
+                $Result = Get-FplPlayer -Name 'ar'
+                $Result | Should -BeNullOrEmpty
             }
             It 'accepts pipeline input on the Name parameter' {
                 $Result = 'Ederson' | Get-FplPlayer


### PR DESCRIPTION
Changes how the `-Name` parameter acts in Get-FplPlayer.

Previously it would do a regex match so if you did `Get-FplPlayer -Name Son` it would get anyone who had `son` in their name rather than the player called Son.

This changes the behaviour so `Get-FplPlayer -Name Son` would return the player Heung-Min Son and if you wanted to get all players with `son` in their name then you must run `Get-FplPlayer -Name '*son*'`

It also changes the name parameter to be the first position parameter allowing you to run `Get-FplPlayer Son`