### PR TITLE
Make git config settings global

### DIFF
--- a/Build/psake.ps1
+++ b/Build/psake.ps1
@@ -12,8 +12,8 @@ Properties {
         $Verbose = @{Verbose = $True}
     }
 
-    git config user.email 'pipeline@example.com'
-    git config user.name 'pipeline'
+    git config --global user.email 'pipeline@example.com'
+    git config --global user.name 'pipeline'
 }
 
 Task Default -Depends Test


### PR DESCRIPTION
A username and email is added to the git config as part of the build script but it was getting added in the local settings and therefore being pushed back to GitHub during the build pipeline. I have now moved this to write it to the global config to avoid this behavour.