### PR TITLE
Fix bug of not being able to captain a player being subbed on

### DIFF
--- a/PSFPL/Private/Find-FplPlayer.ps1
+++ b/PSFPL/Private/Find-FplPlayer.ps1
@@ -12,23 +12,23 @@ Function Find-FplPlayer {
 
     foreach ($Player in $PlayerTransform) {
         if ($Player.PSTypeNames -contains 'FplLineup') {
-            $Player
+            $Player.PSObject.Copy()
             continue
         }
         $SearchName = $Player.Name -Replace '[.^$]'
-        if ($Player.PlayerId) {
-            $PlayerObj = $FplPlayerCollection.Where{$_.PlayerId -eq $Player.PlayerId}
+        $PlayerObj = if ($Player.PlayerId) {
+            $FplPlayerCollection.Where{$_.PlayerId -eq $Player.PlayerId}
         }
         else {
-            $PlayerObj = $FplPlayerCollection.Where{
+            $FplPlayerCollection.Where{
                 $_.Name -match $Player.Name -and
                 $_.Club -match $Player.Club -and
                 $_.Position -match $Player.Position
             }
-            if ($PlayerObj.Count -gt 1) {
-                $Message = 'Multiple players found that match "{0}"' -f $SearchName
-                Write-Error -Message $Message -ErrorAction 'Stop'
-            }
+        }
+        if (@($PlayerObj.Count) -gt 1) {
+            $Message = 'Multiple players found that match "{0}"' -f $SearchName
+            Write-Error -Message $Message -ErrorAction 'Stop'
         }
 
         if (-not $PlayerObj) {
@@ -42,6 +42,6 @@ Function Find-FplPlayer {
             Write-Error -Message $Message -ErrorAction 'Stop'
         }
 
-        $PlayerObj
+        $PlayerObj.PSObject.Copy()
     }
 }

--- a/PSFPL/Private/Set-FplLineupCaptain.ps1
+++ b/PSFPL/Private/Set-FplLineupCaptain.ps1
@@ -17,19 +17,30 @@ function Set-FplLineupCaptain {
         $ViceCaptain
     )
 
+    $OriginalCaptain = $Lineup.Where{$_.IsCaptain}[0]
+    $OriginalViceCaptain = $Lineup.Where{$_.IsViceCaptain}[0]
+
     if ($Captain) {
-        $Lineup.Where{$_.IsCaptain}[0].IsCaptain = $false
+        $OriginalCaptain.IsCaptain = $false
         $NewCaptain = $Lineup.Where{$_.PlayerId -eq $Captain.PlayerId}[0]
         if ($NewCaptain.IsSub) {
             Write-Error -Message "You cannot captain a substitute" -ErrorAction 'Stop'
         }
+        if ($NewCaptain.IsViceCaptain) {
+            $NewCaptain.IsViceCaptain = $false
+            $OriginalCaptain.IsViceCaptain = $true
+        }
         $NewCaptain.IsCaptain = $true
     }
     if ($ViceCaptain) {
-        $Lineup.Where{$_.IsViceCaptain}[0].IsViceCaptain = $false
+        $OriginalViceCaptain.IsViceCaptain = $false
         $NewViceCaptain = $Lineup.Where{$_.PlayerId -eq $ViceCaptain.PlayerId}[0]
         if ($NewViceCaptain.IsSub) {
             Write-Error -Message "You cannot vice captain a substitute" -ErrorAction 'Stop'
+        }
+        if ($NewViceCaptain.IsCaptain) {
+            $NewViceCaptain.IsCaptain = $false
+            $OriginalViceCaptain.IsCaptain = $true
         }
         $NewViceCaptain.IsViceCaptain = $true
     }

--- a/Tests/Private/Find-FplPlayer.tests.ps1
+++ b/Tests/Private/Find-FplPlayer.tests.ps1
@@ -130,17 +130,20 @@ InModuleScope 'PSFPL' {
             $PlayerTransform = [PSCustomObject]@{
                 Name = '^Digne$'
             }
-            Find-FplPlayer -PlayerTransform $PlayerTransform -FplPlayerCollection $Lineup | Should -Be $Digne
+            $Output = Find-FplPlayer -PlayerTransform $PlayerTransform -FplPlayerCollection $Lineup
+            $Output.PlayerID | Should -Be 484
         }
         It 'finds a player based on player ID' {
             $PlayerTransform = [PSCustomObject]@{
                 PlayerID = 484
             }
-            Find-FplPlayer -PlayerTransform $PlayerTransform -FplPlayerCollection $Lineup | Should -Be $Digne
+            $Output = Find-FplPlayer -PlayerTransform $PlayerTransform -FplPlayerCollection $Lineup
+            $Output.PlayerID | Should -Be 484
         }
         It 'finds a player based on FplLineup type' {
             $PlayerTransform = $Digne
-            Find-FplPlayer -PlayerTransform $PlayerTransform -FplPlayerCollection $Lineup | Should -Be $Digne
+            $Output = Find-FplPlayer -PlayerTransform $PlayerTransform -FplPlayerCollection $Lineup
+            $Output.PlayerID | Should -Be 484
         }
         It 'throws if multiple matches are found' {
             $PlayerTransform = [PSCustomObject]@{

--- a/Tests/Private/Set-FplLineupCaptain.Tests.ps1
+++ b/Tests/Private/Set-FplLineupCaptain.Tests.ps1
@@ -42,7 +42,9 @@ InModuleScope 'PSFPL' {
         }
         BeforeEach {
             $Params = @{
-                Lineup = $Fabianski, $Bednarek, $Bennett, $Diop
+                Lineup = foreach ($Player in $Fabianski, $Bednarek, $Bennett, $Diop) {
+                    $Player.PSObject.Copy()
+                }
             }
         }
         It 'sets a new captain' {
@@ -60,6 +62,18 @@ InModuleScope 'PSFPL' {
             $Params['ViceCaptain'] = $Fabianski
             $Result = Set-FplLineupCaptain @Params
             $Result.Where{$_.IsCaptain}.Name | Should -Be 'Bennett'
+            $Result.Where{$_.IsViceCaptain}.Name | Should -Be 'Fabianski'
+        }
+        It 'handles setting the vice captain as the new captain' {
+            $Params['Captain'] = $Bednarek
+            $Result = Set-FplLineupCaptain @Params
+            $Result.Where{$_.IsCaptain}.Name | Should -Be 'Bednarek'
+            $Result.Where{$_.IsViceCaptain}.Name | Should -Be 'Fabianski'
+        }
+        It 'handles setting the captain as the new vice captain' {
+            $Params['ViceCaptain'] = $Fabianski
+            $Result = Set-FplLineupCaptain @Params
+            $Result.Where{$_.IsCaptain}.Name | Should -Be 'Bednarek'
             $Result.Where{$_.IsViceCaptain}.Name | Should -Be 'Fabianski'
         }
         It 'errors if a substitute is set as the new captain' {


### PR DESCRIPTION
Fixes #58 

This PR fixes a bug where you cannot bring a player off of your bench into your starting XI and captain him during the same command.

It also fixes the bug of not being able to set your captain as the player who is a vice captain. The fix will cause the roles to swap so the captain would become the vice captain and the vice captain would become the captain.